### PR TITLE
[MNT] deactivate issue management GHA

### DIFF
--- a/.github/workflows/lock_old_threads.yml
+++ b/.github/workflows/lock_old_threads.yml
@@ -1,8 +1,9 @@
 name: 'Lock Old Threads'
 
-on:
-  schedule:
-    - cron: '45 1 * * *'
+# on:
+#  schedule:
+#  - cron: '45 1 * * *'
+  suspend: true
 
 permissions:
   issues: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: Mark stale issues and pull requests
 
-on:
-  schedule:
-  - cron: "30 1 * * *"
+# on:
+#  schedule:
+#  - cron: "30 1 * * *"
 
 jobs:
   stale:


### PR DESCRIPTION
This PR deactivates issue management GHA jobs for locking and staling issues.

There are two goals in doing this:

* simplify GitHub actions, reduce maintenance surface
* avoid irreversible actions to issue tracker if maintainers are inactive