### PR TITLE
[MNT] CI: Run test workflow also on stacked PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   schedule:
     - cron: "0 5 * * *"
 


### PR DESCRIPTION
Changes the `test` CI job to run test workflow also on stacked PRs (not just PR to `master`).