### PR TITLE
[MNT] remove unnecessary deps - wurlitzer

### DIFF
--- a/pycaret/internal/logging.py
+++ b/pycaret/internal/logging.py
@@ -43,7 +43,6 @@ class redirect_output:
         # Current Python process redirects
         self.redirect_stdout = redirect_stdout(LoggerWriter(self.logger.info))
         self.redirect_stderr = redirect_stderr(LoggerWriter(self.logger.warning))
-        # This redirects stdout/stderr from C libraries and child processes (joblib)
         self.c_redirect = None
 
     def __enter__(self):

--- a/pycaret/internal/logging.py
+++ b/pycaret/internal/logging.py
@@ -13,12 +13,6 @@ from collections.abc import Callable
 from contextlib import redirect_stderr, redirect_stdout
 from typing import Optional, Union
 
-try:
-    from wurlitzer import pipes
-except ImportError:
-    # Fails on windows. See https://github.com/minrk/wurlitzer/pull/63
-    pipes = None
-
 
 # From https://stackoverflow.com/a/66209331
 class LoggerWriter:
@@ -50,14 +44,7 @@ class redirect_output:
         self.redirect_stdout = redirect_stdout(LoggerWriter(self.logger.info))
         self.redirect_stderr = redirect_stderr(LoggerWriter(self.logger.warning))
         # This redirects stdout/stderr from C libraries and child processes (joblib)
-        self.c_redirect = (
-            pipes(
-                stdout=LoggerWriter(self.logger.info),
-                stderr=LoggerWriter(self.logger.warning),
-            )
-            if pipes
-            else None
-        )
+        self.c_redirect = None
 
     def __enter__(self):
         self.redirect_stdout.__enter__()

--- a/pycaret/utils/_show_versions.py
+++ b/pycaret/utils/_show_versions.py
@@ -49,7 +49,6 @@ required_deps = [
     "cloudpickle",
     "deprecation",
     "xxhash",
-    "wurlitzer",
 ]
 
 optional_deps = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ dependencies = [
   "cloudpickle",
   "deprecation>=2.1.0",
   "xxhash",
-  "wurlitzer; platform_system != 'Windows'",
   "trio>=0.22.0,<0.25.0",  # fixes problems about third-party packages, remove after httpcore 1.05
   "setuptools; python_version>='3.12'",
   # Plotting


### PR DESCRIPTION
Remove unnecessary deps - wurlitzer.

The `wurlitzer` package is a core dep but only used in a peripheral way, single-location import, and also only on some operating systems.

This can be removed to move to a more lean depset.