### PR TITLE
[MNT] remove unnecessary deps - notebook/colab related packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,6 @@ dependencies = [
   "numba>=0.55.0",
   "requests>=2.27.1",  # Required by pycaret.datasets
   "psutil>=5.9.0",
-  "markupsafe>=2.0.1",  # Fixes Google Colab issue
-  "importlib_metadata>=4.12.0",
-  "nbformat>=4.2.0",
   "cloudpickle",
   "deprecation>=2.1.0",
   "xxhash",


### PR DESCRIPTION
Removes unnecssary deps:
```
  "markupsafe>=2.0.1",
  "importlib_metadata>=4.12.0",
  "nbformat>=4.2.0",
```

These are not directly imported in the package, and can be removed.