### PR TITLE
[MNT] Remove unused packages - `deprecations`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ dependencies = [
   "requests>=2.27.1",  # Required by pycaret.datasets
   "psutil>=5.9.0",
   "cloudpickle",
-  "deprecation>=2.1.0",
   "xxhash",
   "wurlitzer; platform_system != 'Windows'",
   "trio>=0.22.0,<0.25.0",  # fixes problems about third-party packages, remove after httpcore 1.05


### PR DESCRIPTION
Removes unused packages - `deprecations`.

The package is never imported in the library.