### PR TITLE
[MNT] raise per-test timeout from 60s to 300s in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Install pycaret and dependencies
         shell: bash
-        run: uv pip install .[dev,test,mlops] --no-cache-dir
+        run: uv pip install .[dev,test,mlops,models] --no-cache-dir
         env:
           UV_SYSTEM_PYTHON: 1
 
@@ -217,6 +217,10 @@ jobs:
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
+
+      - name: Install libomp (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libomp
 
       - name: Install pycaret and dependencies
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
         run: uv pip list
 
       - name: Test with pytest
-        run: pytest --durations=0 --timeout=60 -m "not (benchmark or plotting or tuning_random or tuning_grid)"
+        run: pytest --durations=0 --timeout=300 -m "not (benchmark or plotting or tuning_random or tuning_grid)"
 
   test_plots:
     name: Test plotting
@@ -151,7 +151,7 @@ jobs:
         run: uv pip list
 
       - name: Test with pytest
-        run: pytest --durations=0 --timeout=60 -m "plotting"
+        run: pytest --durations=0 --timeout=300 -m "plotting"
 
   test_ts_tune_random:
     name: Test random tuning
@@ -189,7 +189,7 @@ jobs:
         run: uv pip list
 
       - name: Test with pytest
-        run: pytest --durations=0 --timeout=60 -m "tuning_random"
+        run: pytest --durations=0 --timeout=300 -m "tuning_random"
 
   test_ts_tune_grid:
     name: Test grid tuning
@@ -228,7 +228,7 @@ jobs:
         run: uv pip list
 
       - name: Test with pytest
-        run: pytest --durations=0 --timeout=60 -m "tuning_grid"
+        run: pytest --durations=0 --timeout=300 -m "tuning_grid"
 
   test_benchmarks:
     runs-on: ubuntu-latest
@@ -265,4 +265,4 @@ jobs:
         run: uv pip list
 
       - name: Run benchmarks
-        run: pytest --durations=0 --timeout=60 -m "benchmark"
+        run: pytest --durations=0 --timeout=300 -m "benchmark"


### PR DESCRIPTION
300s stays far above every observed real duration while still catching genuine hangs.
Also adds libopms for plotting failure on MacOS CI along with [models] installation t recover from xgboost failures.