### PR TITLE
[MNT] fix CI trigger in `test.yml` to watch `main` branch after rename

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: pycaret
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   schedule:
     - cron: "0 5 * * *"


### PR DESCRIPTION
fixes the CI trigger in `test.yml` to watch the `main` branch after rename