### PR TITLE
[MNT] in CI, add missing `needs` gating condition to benchmark step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,13 +192,14 @@ jobs:
         run: pytest --durations=0 --timeout=60 -m  "(tuning_grid or tuning_random)"
 
   test_benchmarks:
+    name: Benchmark tests
+    needs: code-quality
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
-    name: Benchmark tests
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4


### PR DESCRIPTION
fixes a minor oversight post rework of `test.yml: adds a missing `needs` gating condition to benchmark step