### PR TITLE
Revert "[MNT] remove unnecessary dependencies - `numba`"

### DIFF
--- a/pycaret/utils/_show_versions.py
+++ b/pycaret/utils/_show_versions.py
@@ -30,6 +30,7 @@ required_deps = [
     "imblearn",
     "category_encoders",
     "lightgbm",
+    "numba",
     "requests",
     "matplotlib",
     "scikitplot",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
   "imbalanced-learn>=0.12.0",  # >=0.12.0 to support scikit-learn 1.4
   "category-encoders>=2.4.0",
   "lightgbm>=3.0.0",
+  "numba>=0.55.0",
   "requests>=2.27.1",  # Required by pycaret.datasets
   "psutil>=5.9.0",
   "cloudpickle",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,38 @@
+from unittest.mock import patch
+
+import numba
+import pytest
+from numba.core.dispatcher import Dispatcher
+
 import pycaret.datasets
 from pycaret.anomaly import AnomalyExperiment
 from pycaret.classification import ClassificationExperiment
 from pycaret.clustering import ClusteringExperiment
 from pycaret.regression import RegressionExperiment
 from pycaret.time_series import TSForecastingExperiment
+
+
+@pytest.fixture
+def disable_numba():
+    """
+    Forces numba to use the original python functions.
+
+    This is required as numba code in pyod (anomaly) seems to not work
+    correctly leading to exceptions if ran from within pytest.
+    """
+    old = numba.config.DISABLE_JIT
+    # This will not affect already compiled functions...
+    numba.config.DISABLE_JIT = True
+
+    # ...which is why we force the Numba dispatcher to simply
+    # call the underlying python function for already compiled
+    # ones
+    def pyfunc_call(self, *args, **kwargs):
+        return self.py_func(*args, **kwargs)
+
+    with patch.object(Dispatcher, "__call__", pyfunc_call):
+        yield
+    numba.config.DISABLE_JIT = old
 
 
 def check_exp(exp, **kwargs):
@@ -56,7 +85,7 @@ def test_model_equality_clustering():
     check_exp(exp)
 
 
-def test_model_equality_anomaly():
+def test_model_equality_anomaly(disable_numba):
     exp = AnomalyExperiment()
     exp.setup(
         pycaret.datasets.get_data("anomaly"),


### PR DESCRIPTION
Reverts sktime/pycaret#23 - `numba` seems coupled to tests as well as one specific estimator.

This feels like bad design and too high coupling, but is outside the scope of the initial restoration work. Also see discussion in #30.