### PR TITLE
[MNT] Create `CODEOWNERS` file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# The file specifies framework level core developers for automated review requests
+
+* @amotl @fkiraly @williamjudge94


### PR DESCRIPTION
Adds the current active maintainers of this project to the `CODEOWNERS` file

Afaik these are:

* @williamjudge94
* @amotl 
* myself