### PR TITLE
[MNT] Fix docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,9 +17,14 @@ sphinx:
 #formats:
 #  - pdf
 
-# Optionally set the version of Python and requirements required to build your docs
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
 python:
   install:
-    - requirements: docs/source/requirements.txt
-    - requirements: requirements.txt
-    - requirements: requirements-optional.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,10 +40,9 @@ pytest pycaret
 # Documentation
 We use [`sphinx`](https://www.sphinx-doc.org/) to build our documentation and [readthedocs](https://pycaret.readthedocs.io/en/latest/index.html) to host it. The source files can be found in [`docs/source/`](docs/source). The main configuration file for sphinx is [`conf.py`](docs/source/conf.py) and the main page is [`index.rst`](docs/source/index.rst).
 
-To build the documentation locally, you need to install a few extra dependencies listed in
-[`docs/source/requirements.txt`](docs/source/requirements.txt):
+To build the documentation locally, you need to the documentation dependency set:
 ```shell
-pip install -r docs/source/requirements.txt
+pip install -e ".[docs]"
 ```
 To build the website locally, run:
 ```shell

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,12 +19,9 @@ sys.path.insert(0, os.path.abspath("../.."))
 # -- Project information -----------------------------------------------------
 
 project = "pycaret"
-copyright = "Copyright (C) 2020-2024 PyCaret"
-author = "Moez Ali"
-contributors = "https://github.com/pycaret/pycaret/graphs/contributors"
-
-# The full version, including alpha/beta/rc tags
-release = "3.4.0"
+copyright = "Copyright (C) 2026-present PyCaret maintainers"
+author = "pycaret maintainers"
+contributors = "https://github.com/sktime/pycaret/graphs/contributors"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -95,12 +95,12 @@ Documentation
 -------------
 We use `sphinx <https://www.sphinx-doc.org/>`_ to build our documentation and `readthedocs <https://pycaret.readthedocs.io/en/latest/index.html>`_ to host it. The source files can be found in ``docs/source/``. The main configuration file for sphinx is ``conf.py`` and the main page is ``index.rst``.
 
-To build the documentation locally, you need to install a few extra dependencies listed in
-``docs/source/requirements.txt``:
+To build the documentation locally, you need to install the documentation
+dependency set.
 
 .. code-block:: shell
 
-    pip install -r docs/source/requirements.txt
+    pip install -e ".[docs]"
 
 To build the website locally, run:
 

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,0 @@
-sphinx>=3.0.0
-sphinx-rtd-theme>=0.5.0
-numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,13 +214,20 @@ prophet = [
   "prophet>=1.0.1",
 ]
 
-# dev - the developer dependency set, for contributors to sktime
+# dev - the developer dependency set, for contributors
 dev = [
   "black>=24.8.0",
   "isort>=5.13.2",
   "flake8>=7.1.1",
   "setuptools>=71.1.0",
   "mypy>=1.0.0",
+]
+
+# docs - the dependency set used for doc build
+docs = [
+  "sphinx>=3.0.0",
+  "sphinx-rtd-theme>=0.5.0",
+  "numpy",
 ]
 
 


### PR DESCRIPTION
Fixes the docs build:

* moves requirements to `pyproject.toml`
* updates `readthedocs.yml`