### PR TITLE
[MNT] change package name to `pycaret-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pycaret"
+name = "pycaret-core"
 version = "3.5.0"
 description = "PyCaret - An open source, low-code machine learning library in Python."
 readme = "README.md"


### PR DESCRIPTION
Changes the pypi package name to `pycaret-core`.

Does not update documentation - that is done here: https://github.com/sktime/pycaret/pull/51