### PR TITLE
[MNT] temporary fix for yellowbrick incompatibility with matplotlib >= 3.11

### DIFF
--- a/pycaret/internal/patches/yellowbrick.py
+++ b/pycaret/internal/patches/yellowbrick.py
@@ -1,3 +1,13 @@
+import matplotlib.cm
+import matplotlib.pyplot
+
+# matplotlib 3.11 removed matplotlib.cm.get_cmap, which yellowbrick (unmaintained)
+# still calls in yellowbrick.style.colors and yellowbrick.features.base.
+# Restore it until yellowbrick is replaced, see #49.
+
+if not hasattr(matplotlib.cm, "get_cmap"):
+    matplotlib.cm.get_cmap = matplotlib.pyplot.get_cmap
+
 from yellowbrick.utils.helpers import get_model_name as get_model_name_original
 
 from pycaret.internal.meta_estimators import get_estimator_from_meta_estimator

--- a/pycaret/internal/patches/yellowbrick.py
+++ b/pycaret/internal/patches/yellowbrick.py
@@ -1,13 +1,3 @@
-import matplotlib.cm
-import matplotlib.pyplot
-
-# matplotlib 3.11 removed matplotlib.cm.get_cmap, which yellowbrick (unmaintained)
-# still calls in yellowbrick.style.colors and yellowbrick.features.base.
-# Restore it until yellowbrick is replaced, see #49.
-
-if not hasattr(matplotlib.cm, "get_cmap"):
-    matplotlib.cm.get_cmap = matplotlib.pyplot.get_cmap
-
 from yellowbrick.utils.helpers import get_model_name as get_model_name_original
 
 from pycaret.internal.meta_estimators import get_estimator_from_meta_estimator

--- a/pycaret/internal/pycaret_experiment/tabular_experiment.py
+++ b/pycaret/internal/pycaret_experiment/tabular_experiment.py
@@ -533,9 +533,17 @@ class _TabularExperiment(_PyCaretExperiment):
             "yellowbrick.utils.types.is_estimator",
             pycaret.internal.patches.yellowbrick.is_estimator,
         ):
-            with patch(
-                "yellowbrick.utils.helpers.is_estimator",
-                pycaret.internal.patches.yellowbrick.is_estimator,
+            # matplotlib >= 3.11 removed matplotlib.cm.get_cmap, which yellowbrick
+            # (unmaintained) still calls at plot time; restore it only for the
+            # duration of the plot call, see #49. create=True adds the attribute
+            # if absent and removes it again on exit, so matplotlib remains
+            # unmodified outside this block.
+            with (
+                patch("matplotlib.cm.get_cmap", plt.get_cmap, create=True),
+                patch(
+                    "yellowbrick.utils.helpers.is_estimator",
+                    pycaret.internal.patches.yellowbrick.is_estimator,
+                ),
             ):
                 _base_dpi = 100
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,8 @@ dependencies = [
   "setuptools; python_version>='3.12'",
   "packaging>=21.0",
   # Plotting
-  "matplotlib>=3.5.0,<3.8.0; python_version<'3.13'",
-  "matplotlib>=3.8.0,<3.11.0; python_version>='3.13'",
+  "matplotlib>=3.5.0,<3.12.0; python_version<'3.13'",
+  "matplotlib>=3.8.0,<3.12.0; python_version>='3.13'",
   "mljar-scikit-plot",
   "yellowbrick>=1.4; python_version<'3.13'",
   "yellowbrick>=1.5; python_version>='3.13'",


### PR DESCRIPTION
Temporary fix for #49.

- matplotlib 3.11 removed `matplotlib.cm.get_cmap`, which yellowbrick still calls (`yellowbrick.style.colors`, `yellowbrick.features.base`). This restores the alias in `pycaret.internal.patches.yellowbrick`.
- raises the matplotlib upper bound to `<3.12`. The old `<3.8` cap for py<3.13 was for the `cooks` plot, which remains via the existing `NotImplementedError` on matplotlib >= 3.8.

Verified locally: full plotting suite (22 tests) passes with matplotlib 3.11.1 forced. Note that CI's `[full]` env still resolves matplotlib to 3.10.0 because `ydata-profiling` caps `matplotlib<=3.10`, so 3.11 is only reachable in core installs.
Heads-up for the follow-up: yellowbrick also uses `ListedColormap(N=...)`, deprecated since matplotlib 3.11 and scheduled for removal in 3.13.