### PR TITLE
[MNT] replace scattered copyright statements with pointers to LICENSE, clean up author statements

### DIFF
--- a/pycaret/anomaly/functional.py
+++ b/pycaret/anomaly/functional.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import logging

--- a/pycaret/classification/functional.py
+++ b/pycaret/classification/functional.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import logging

--- a/pycaret/classification/oop.py
+++ b/pycaret/classification/oop.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import datetime

--- a/pycaret/clustering/functional.py
+++ b/pycaret/clustering/functional.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import logging

--- a/pycaret/containers/base_container.py
+++ b/pycaret/containers/base_container.py
@@ -1,6 +1,5 @@
 # Module: containers.base_container
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 import inspect
 from typing import Any, Dict, Optional

--- a/pycaret/containers/metrics/anomaly.py
+++ b/pycaret/containers/metrics/anomaly.py
@@ -1,6 +1,5 @@
 # Module: containers.metrics.anomaly
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 # The purpose of this module is to serve as a central repository of anomaly metrics. The `anomaly` module will
 # call `get_all_metrics_containers()`, which will return instances of all classes in this module that have `AnomalyMetricContainer`

--- a/pycaret/containers/metrics/base_metric.py
+++ b/pycaret/containers/metrics/base_metric.py
@@ -3,7 +3,6 @@
 # Module: containers.metrics.base_metric
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 from typing import Any, Dict, Optional, Union

--- a/pycaret/containers/metrics/classification.py
+++ b/pycaret/containers/metrics/classification.py
@@ -3,7 +3,6 @@
 # Module: containers.metrics.classification
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 # The purpose of this module is to serve as a central repository of classification metrics. The `classification` module will
 # call `get_all_metrics_containers()`, which will return instances of all classes in this module that have `ClassificationMetricContainer`

--- a/pycaret/containers/metrics/clustering.py
+++ b/pycaret/containers/metrics/clustering.py
@@ -3,7 +3,6 @@
 # Module: containers.metrics.clustering
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 # The purpose of this module is to serve as a central repository of clustering metrics. The `clustering` module will
 # call `get_all_metrics_containers()`, which will return instances of all classes in this module that have `ClusterMetricContainer`

--- a/pycaret/containers/metrics/regression.py
+++ b/pycaret/containers/metrics/regression.py
@@ -1,6 +1,5 @@
 # Module: containers.metrics.regression
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 # The purpose of this module is to serve as a central repository of regression metrics. The `regression` module will
 # call `get_all_metrics_containers()`, which will return instances of all classes in this module that have `RegressionMetricContainer`

--- a/pycaret/containers/metrics/time_series.py
+++ b/pycaret/containers/metrics/time_series.py
@@ -1,6 +1,5 @@
 # Module: containers.metrics.time_series
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com> and Miguel Trejo <amtrema@hotmail.com>
-# License: MIT
 
 # The purpose of this module is to serve as a central repository of time series metrics. The `time_series` module will
 # call `get_all_metrics_containers()`, which will return instances of all classes in this module that have `TimeSeriesMetricContainer`

--- a/pycaret/containers/models/anomaly.py
+++ b/pycaret/containers/models/anomaly.py
@@ -1,6 +1,5 @@
 # Module: containers.models.anomaly
 # Author: Moez Ali <moez.ali@queensu.ca> and Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 # The purpose of this module is to serve as a central repository of anomaly models. The `anomaly` module will
 # call `get_all_model_containers()`, which will return instances of all classes in this module that have `ClassifierContainer`

--- a/pycaret/containers/models/base_model.py
+++ b/pycaret/containers/models/base_model.py
@@ -1,6 +1,5 @@
 # Module: containers.models.base_model
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 from typing import Any, Dict, List, Optional
 

--- a/pycaret/containers/models/classification.py
+++ b/pycaret/containers/models/classification.py
@@ -1,6 +1,5 @@
 # Module: containers.models.classification
 # Author: Moez Ali <moez.ali@queensu.ca> and Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 # The purpose of this module is to serve as a central repository of classification models. The `classification` module will
 # call `get_all_model_containers()`, which will return instances of all classes in this module that have `ClassifierContainer`

--- a/pycaret/containers/models/clustering.py
+++ b/pycaret/containers/models/clustering.py
@@ -1,6 +1,5 @@
 # Module: containers.models.clustering
 # Author: Moez Ali <moez.ali@queensu.ca> and Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 # The purpose of this module is to serve as a central repository of clustering models. The `clustering` module will
 # call `get_all_model_containers()`, which will return instances of all classes in this module that have `ClassifierContainer`

--- a/pycaret/containers/models/regression.py
+++ b/pycaret/containers/models/regression.py
@@ -1,6 +1,5 @@
 # Module: containers.models.regression
 # Author: Moez Ali <moez.ali@queensu.ca> and Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 # The purpose of this module is to serve as a central repository of regression models. The `regression` module will
 # call `get_all_model_containers()`, which will return instances of all classes in this module that have `RegressionContainer`

--- a/pycaret/internal/display/display.py
+++ b/pycaret/internal/display/display.py
@@ -1,6 +1,5 @@
 # Module: internal.display class
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 from typing import Any, Dict, List, Optional
 

--- a/pycaret/internal/distributions.py
+++ b/pycaret/internal/distributions.py
@@ -1,6 +1,5 @@
 # Module: internal.distributions
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 from typing import Dict, Optional
 

--- a/pycaret/internal/logging.py
+++ b/pycaret/internal/logging.py
@@ -3,7 +3,6 @@
 # Module: internal.logging
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 import logging
 import os

--- a/pycaret/internal/metrics.py
+++ b/pycaret/internal/metrics.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import traceback

--- a/pycaret/internal/patches/sklearn.py
+++ b/pycaret/internal/patches/sklearn.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 from collections.abc import Callable

--- a/pycaret/internal/persistence.py
+++ b/pycaret/internal/persistence.py
@@ -1,6 +1,5 @@
 # Module: internal.persistence
 # Author: Moez Ali <moez.ali@queensu.ca> and Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 import gc
 import os
 from typing import Dict, Optional

--- a/pycaret/internal/pipeline.py
+++ b/pycaret/internal/pipeline.py
@@ -1,6 +1,5 @@
 # Module: internal.pipeline
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 # Provides a Pipeline supporting partial_fit (needed for tune warm start)
 # and copying over fit attributes from the final estimator, so that it can be plotted directly

--- a/pycaret/internal/plots/yellowbrick.py
+++ b/pycaret/internal/plots/yellowbrick.py
@@ -1,6 +1,5 @@
 # Module: internal.plotting
 # Author: Moez Ali <moez.ali@queensu.ca> and Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 import os
 from typing import Optional

--- a/pycaret/internal/preprocess/preprocessor.py
+++ b/pycaret/internal/preprocess/preprocessor.py
@@ -1,5 +1,4 @@
 # Author: Mavs (m.524687@gmail.com)
-# License: MIT
 
 from copy import deepcopy
 

--- a/pycaret/internal/preprocess/transformers.py
+++ b/pycaret/internal/preprocess/transformers.py
@@ -1,5 +1,4 @@
 # Author: Mavs (m.524687@gmail.com)
-# License: MIT
 
 
 import re

--- a/pycaret/internal/pycaret_experiment/pycaret_experiment.py
+++ b/pycaret/internal/pycaret_experiment/pycaret_experiment.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import inspect

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import datetime

--- a/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/unsupervised_experiment.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import datetime

--- a/pycaret/internal/tunable.py
+++ b/pycaret/internal/tunable.py
@@ -1,6 +1,5 @@
 # Module: internal.tunable
 # Author: Antoni Baum (Yard1) <antoni.baum@protonmail.com>
-# License: MIT
 
 # Provides a VotingClassifier which weights can be tuned.
 

--- a/pycaret/parallel/fugue_backend.py
+++ b/pycaret/parallel/fugue_backend.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 import random
 from collections.abc import Callable

--- a/pycaret/regression/functional.py
+++ b/pycaret/regression/functional.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import logging

--- a/pycaret/regression/oop.py
+++ b/pycaret/regression/oop.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import logging

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 """Functional API for Time Series Forecasting Experiment

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import datetime

--- a/pycaret/utils/generic.py
+++ b/pycaret/utils/generic.py
@@ -1,7 +1,5 @@
-# Copyright (C) 2019-2024 PyCaret
-# Author: Moez Ali (moez.ali@queensu.ca)
+# copyright: PyCaret developers, MIT License (see LICENSE file)
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
-# License: MIT
 
 
 import functools


### PR DESCRIPTION
replaces scattered copyright statements with pointers to LICENSE.

Also removes some authors statements that seem inconsistent with the actual git history.
(the git history is entirely preserved and can speak for itself)

