### PR TITLE
[MNT] Validate Python 3.14t (free threading) on CI/GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest' ]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
 
     defaults:
       run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
   "Operating System :: POSIX",
   "Operating System :: Unix",
   "Programming Language :: Python",
+  "Programming Language :: Python :: Free Threading",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Hi. Python provides GA releases of its free-threading variant starting with Python 3.13. This patch makes CI/GHA validate the codebase against Python3.14t, which, I believe, will be good enough.

> Starting with the 3.13 release, CPython has support for a build of
> Python called free threading where the global interpreter lock (GIL)
> is disabled.
>
> -- https://docs.python.org/3/howto/free-threading-python.html
