### PR TITLE
[MNT] clean up .gitignore and ignore pycaret_core.egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,40 +1,36 @@
+# Python
+__pycache__/
+*.pyc
+/build
+/dist
+/*.egg-info
+
+# Virtual environments
 venv/
-.ipynb_checkpoints/
+/.venv*
+
+# Tool caches
 .mypy_cache/
 .pytest_cache/
-__pycache__/
-mlruns/
-catboost_info/
-/stacker.py
-/stacknet.py
-/cli.py
-/app.py
-/cli_app.py
-/logo.png
-/model
-/Results.html
-/build
-/pycaret_nightly.egg-info
-/pycaret.egg-info
-/dist
+.ipynb_checkpoints/
+
+# IDE and editor
 .vscode/settings.json
 *code-workspace
-/logs.log
-examples/logs.log
-.log
-tutorials/logs.log
-/docs/build
 .idea/
+/.devcontainer
+.DS_Store
+
+# Docs
+/docs/build
+
+# Runtime artifacts from running pycaret
 *.log
-trained_models/
-*.pkl
+mlruns/
 /mlruns.db
 /mlruns.db-journal
-mlflow_backend.py
-demo4.py
+catboost_info/
 dask*/
-/.venv*
-/.devcontainer
+trained_models/
+*.pkl
 tmp/
-nbtest1.ipynb
-.DS_Store


### PR DESCRIPTION
#### Problem

Since the package rename to `pycaret-core` (#52), `pip install -e .` writes `pycaret_core.egg-info/`, which `.gitignore` does not cover (it lists only `/pycaret.egg-info` and `/pycaret_nightly.egg-info`), so the directory shows up as untracked in every checkout.

The file had also accumulated entries over time without structure: personal scratch files such as `/stacker.py`, `/cli.py`, `/demo4.py`, `/nbtest1.ipynb`, and `/Results.html`, plus four log rules that `*.log` already covers.

#### Change

- Replace the two package-specific egg-info rules with `/*.egg-info`.
- Group the rules by category (Python, virtual environments, tool caches, IDE, docs, runtime artifacts).
- Remove the personal scratch-file entries and the redundant log rules.
- Add `*.pyc` for stray bytecode files outside `__pycache__/`.

