### PR TITLE
[MNT] Update Docker Image files

### DIFF
--- a/Docker_files/pycaret_full/Dockerfile
+++ b/Docker_files/pycaret_full/Dockerfile
@@ -1,6 +1,6 @@
 # author Fahad Akbar (fahadakbar@gmail.com)
 # Choose image
-FROM jupyter/base-notebook:latest
+FROM quay.io/jupyter/base-notebook:latest
 
 # name your environment and choose python 3.x version
 ARG conda_env=pycaret_full
@@ -17,10 +17,10 @@ RUN "${CONDA_DIR}/envs/${conda_env}/bin/python" -m ipykernel install --user --na
     fix-permissions "/home/${NB_USER}"
 
 # install pycaret full version
-RUN "${CONDA_DIR}/envs/${conda_env}/bin/pip" install pycaret[full]>=3.3.2
+RUN "${CONDA_DIR}/envs/${conda_env}/bin/pip" install "pycaret-core[full]>=3.5.0"
 
 # prepend conda environment to path
-ENV PATH "${CONDA_DIR}/envs/${conda_env}/bin:${PATH}"
+ENV PATH="${CONDA_DIR}/envs/${conda_env}/bin:${PATH}"
 
 # make the env default
-ENV CONDA_DEFAULT_ENV ${conda_env}
+ENV CONDA_DEFAULT_ENV=${conda_env}

--- a/Docker_files/pycaret_slim/Dockerfile
+++ b/Docker_files/pycaret_slim/Dockerfile
@@ -1,6 +1,6 @@
 # author Fahad Akbar , fahadakbar@gmail.com
 # Choose base image
-FROM jupyter/base-notebook:latest
+FROM quay.io/jupyter/base-notebook:latest
 
 # name your environment and choose python 3.x version
 ARG conda_env=pycaret
@@ -17,11 +17,11 @@ RUN "${CONDA_DIR}/envs/${conda_env}/bin/python" -m ipykernel install --user --na
     fix-permissions "/home/${NB_USER}"
 
 # install pycaret light version
-RUN "${CONDA_DIR}/envs/${conda_env}/bin/pip" install pycaret>=3.3.2
+RUN "${CONDA_DIR}/envs/${conda_env}/bin/pip" install "pycaret-core>=3.5.0"
 
 
 # prepend conda environment to path
-ENV PATH "${CONDA_DIR}/envs/${conda_env}/bin:${PATH}"
+ENV PATH="${CONDA_DIR}/envs/${conda_env}/bin:${PATH}"
 
 # make this environment to be the default one
-ENV CONDA_DEFAULT_ENV ${conda_env}
+ENV CONDA_DEFAULT_ENV=${conda_env}


### PR DESCRIPTION
## What does this PR do?

Updates the two Dockerfiles under `Docker_files/`,

Changes to both `pycaret_slim/Dockerfile` and `pycaret_full/Dockerfile`:

* **Base image migrated to Quay.io.** The images used
  `jupyter/base-notebook:latest` from Docker Hub, which has been frozen since
  2023-10-20 — the Jupyter Docker Stacks project only pushes to Quay.io since
  then ([docs](https://jupyter-docker-stacks.readthedocs.io/en/latest/),
  [background](https://github.com/jupyterhub/team-compass/issues/688)). The
  Docker Hub `latest` tag resolves to an October 2023 image (Python 3.11.6,
  IPython 8.16.1) with ~3 years of missed updates. Switched to
  `quay.io/jupyter/base-notebook:latest`.

* **Install `pycaret-core`.** The PyPI package is now `pycaret-core` (currently 3.5.0),
  so the images now install `pycaret-core>=3.5.0` /
  `pycaret-core[full]>=3.5.0`.

* **Modernized `ENV` syntax.** Replaced the deprecated `ENV key value` form
  with `ENV key=value`; Docker emits `LegacyKeyValueFormat` warnings for the
  old form.

## Verification

Built and tested locally with Docker 29.1.3:

* Old `pycaret_slim` image (for comparison): builds, but on the frozen 2023
  base, with the `=3.3.2` redirection artifact present and two
  `LegacyKeyValueFormat` build warnings.
* New `pycaret_slim` image: builds cleanly with no warnings; installs
  pycaret-core 3.5.0 (sktime 1.1.0, scikit-learn 1.4.2) on Python 3.11.16
* New `pycaret_full` image: builds cleanly with no warnings; installs
  pycaret-core 3.5.0 with the `full` extras (sktime 1.1.0, xgboost 3.0.5,
  catboost 1.2.10, shap 0.49.1) on Python 3.11.16, `import pycaret` succeeds,
  and the `pycaret_full` Jupyter kernel is registered.

## Notes

* The Jupyter base image activates its base conda env at container start, so a
  bare `python` in `docker run` resolves to the base env; the pycaret env is
  reached through the registered `pycaret` Jupyter kernel. This behavior is
  unchanged from the old images.
* Out of scope, possible follow-ups: pointing the `docker` ecosystem in
  `dependabot.yml` at the `Docker_files/*` directories (it currently scans `/`
  and finds nothing), and bumping the EOL `python:3.8-slim` default in
  `create_docker()`.
