### PR TITLE
[DOC] Update links to docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/installation_issue.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue.md
@@ -11,7 +11,7 @@ assignees: ''
 <!--
 Please check the box below by replacing [ ] with [x] after confirming.
 -->
-- [ ] I have read the [installation guide](https://py-caret.readthedocs.io/en/latest/installation.html).
+- [ ] I have read the [installation guide](https://www.pycaret.net/en/latest/installation.html).
 
 **Platform**
 <!--

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,14 @@ There is always a room for improvement in documentation. We welcome all the pull
 
 - [Official Documentation](https://github.com/sktime/pycaret-docs) 
 - [Tutorials](https://github.com/sktime/pycaret/tree/main/tutorials)
-- [Docstrings](https://py-caret.readthedocs.io/en/stable/)
+- [Docstrings](https://www.pycaret.net/en/stable/)
 
 # Open Issues
 If you would like to help in working on open issues. Lookout for following tags: `good first issue`, `help wanted`, and `open for contribution`.
 
 
 # Development setup
-Follow [installation instructions](https://py-caret.readthedocs.io/en/latest/installation.html#installing-the-latest-release) to first create a virtual environment. Then, install the development version of the package:
+Follow [installation instructions](https://www.pycaret.net/en/latest/installation.html#installing-the-latest-release) to first create a virtual environment. Then, install the development version of the package:
 ```shell
 pip install -e .[test]
 ```
@@ -38,7 +38,7 @@ pytest pycaret
 ```
 
 # Documentation
-We use [`sphinx`](https://www.sphinx-doc.org/) to build our documentation and [readthedocs](https://py-caret.readthedocs.io/en/latest/index.html) to host it. The source files can be found in [`docs/source/`](docs/source). The main configuration file for sphinx is [`conf.py`](docs/source/conf.py) and the main page is [`index.rst`](docs/source/index.rst).
+We use [`sphinx`](https://www.sphinx-doc.org/) to build our documentation and [readthedocs](https://www.pycaret.net/en/latest/index.html) to host it. The source files can be found in [`docs/source/`](docs/source). The main configuration file for sphinx is [`conf.py`](docs/source/conf.py) and the main page is [`index.rst`](docs/source/index.rst).
 
 To build the documentation locally, you need to the documentation dependency set:
 ```shell

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://py-caret.readthedocs.io/en/latest/"><img src="https://github.com/sktime/pycaret/blob/main/docs/images/logo.png?raw=1" width="175" align="right" /></a>
+<a href="https://www.pycaret.net/en/latest/"><img src="https://github.com/sktime/pycaret/blob/main/docs/images/logo.png?raw=1" width="175" align="right" /></a>
 
 ## **PyCaret - the open-source, low-code machine learning framework**
 
@@ -13,12 +13,12 @@ professionally maintained, with a permissive license, and published under
 the PyPI name `pycaret-core`. It is maintained in direct continuity of `pycaret 3`.
 
 
-|  | **[Documentation](https://py-caret.readthedocs.io/en/latest/)** · **[Tutorials](https://py-caret.readthedocs.io/en/latest/tutorials.html)** · **[Release Notes](https://github.com/sktime/pycaret/releases)** |
+|  | **[Documentation](https://www.pycaret.net/en/latest/)** · **[Tutorials](https://www.pycaret.net/en/latest/tutorials.html)** · **[Release Notes](https://github.com/sktime/pycaret/releases)** |
 |---|---|
 | **Open&#160;Source** | [![License](https://img.shields.io/pypi/l/ansicolortags.svg)](https://img.shields.io/pypi/l/ansicolortags.svg) [![GC.OS Sponsored](https://img.shields.io/badge/GC.OS-Sponsored%20Project-orange.svg?style=flat&colorA=0eac92&colorB=2077b4)](https://www.gcos.ai/) |
 | **Tutorials** | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sktime/pycaret/main?filepath=tutorials) |
 | **Community** | [![!discord](https://img.shields.io/static/v1?logo=discord&label=discord&message=chat&color=lightgreen)](https://discord.com/invite/54ACzaFsn7) [![!slack](https://img.shields.io/static/v1?logo=linkedin&label=LinkedIn&message=news&color=lightblue)](https://www.linkedin.com/company/scikit-time/)  |
-| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/sktime/pycaret/release.yml?logo=github)](https://github.com/sktime/pycaret/actions/workflows/release.yml) [![readthedocs](https://img.shields.io/readthedocs/py-caret?logo=readthedocs)](https://py-caret.readthedocs.io/en/latest/tutorials.html) |
+| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/sktime/pycaret/release.yml?logo=github)](https://github.com/sktime/pycaret/actions/workflows/release.yml) [![readthedocs](https://img.shields.io/readthedocs/py-caret?logo=readthedocs)](https://www.pycaret.net/en/latest/tutorials.html) |
 | **Code** |  [![!pypi](https://img.shields.io/pypi/v/pycaret-core?color=orange)](https://pypi.org/project/pycaret-core/) [![!python-versions](https://img.shields.io/pypi/pyversions/pycaret-core)](https://www.python.org/) [![!black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)  |
 | **Downloads**| [![Downloads](https://static.pepy.tech/personalized-badge/pycaret?period=week&units=international_system&left_color=grey&right_color=blue&left_text=weekly%20(pypi))](https://pepy.tech/project/pycaret) [![Downloads](https://static.pepy.tech/personalized-badge/pycaret?period=month&units=international_system&left_color=grey&right_color=blue&left_text=monthly%20(pypi))](https://pepy.tech/project/pycaret) [![Downloads](https://static.pepy.tech/personalized-badge/pycaret?period=total&units=international_system&left_color=grey&right_color=blue&left_text=cumulative%20(pypi))](https://pepy.tech/project/pycaret) |
 
@@ -243,7 +243,7 @@ PyCaret is completely free and open-source and licensed under the [MIT](https://
 | ✈️ **[Cheat sheet]**            | Community Cheat sheet            |
 | :hammer_and_wrench: **[Release Notes]**          | Release Notes          |
 
-[Tutorials]: https://py-caret.readthedocs.io/en/latest/tutorials.html
+[Tutorials]: https://www.pycaret.net/en/latest/tutorials.html
 [Documentation]: https://pycaret.gitbook.io/docs/
 [Videos]: https://pycaret.gitbook.io/docs/learn-pycaret/videos
 [Cheat sheet]: https://pycaret.gitbook.io/docs/learn-pycaret/cheat-sheet

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -55,7 +55,7 @@ What we currently need help on?
 
 Development setup
 -----------------
-Follow `installation instructions <https://py-caret.readthedocs.io/en/latest/installation.html#installing-the-latest-release>`_ to first create a virtual environment. Then, install development version of the package:
+Follow `installation instructions <https://www.pycaret.net/en/latest/installation.html#installing-the-latest-release>`_ to first create a virtual environment. Then, install development version of the package:
 
 .. code-block:: shell
 
@@ -93,7 +93,7 @@ To run tests, except skipped ones (search for ``@pytest.mark.skip`` decorator ov
 
 Documentation
 -------------
-We use `sphinx <https://www.sphinx-doc.org/>`_ to build our documentation and `readthedocs <https://py-caret.readthedocs.io/en/latest/index.html>`_ to host it. The source files can be found in ``docs/source/``. The main configuration file for sphinx is ``conf.py`` and the main page is ``index.rst``.
+We use `sphinx <https://www.sphinx-doc.org/>`_ to build our documentation and `readthedocs <https://www.pycaret.net/en/latest/index.html>`_ to host it. The source files can be found in ``docs/source/``. The main configuration file for sphinx is ``conf.py`` and the main page is ``index.rst``.
 
 To build the documentation locally, you need to install the documentation
 dependency set.

--- a/pycaret/internal/pycaret_experiment/pycaret_experiment.py
+++ b/pycaret/internal/pycaret_experiment/pycaret_experiment.py
@@ -141,7 +141,7 @@ class _PyCaretExperiment:
         if not self._setup_ran:
             raise RuntimeError(
                 "This function/method requires the users to run setup() first."
-                "\nMore info: https://py-caret.readthedocs.io/en/latest/installation.html"
+                "\nMore info: https://www.pycaret.net/en/latest/installation.html"
             )
 
     def deploy_model(

--- a/pycaret/internal/pycaret_experiment/pycaret_experiment.py
+++ b/pycaret/internal/pycaret_experiment/pycaret_experiment.py
@@ -140,7 +140,7 @@ class _PyCaretExperiment:
         """
         if not self._setup_ran:
             raise RuntimeError(
-                "This function/method requires the users to run setup() first."
+                "This function/method requires the user to run setup() first."
                 "\nMore info: https://www.pycaret.net/en/latest/installation.html"
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,10 +242,10 @@ test = [
 
 
 [project.urls]
-"API Reference" = "https://py-caret.readthedocs.io/en/latest/"
-Documentation = "https://py-caret.readthedocs.io/en/latest/"
+"API Reference" = "https://www.pycaret.net/en/latest/"
+Documentation = "https://www.pycaret.net/en/latest/"
 Download = "https://pypi.org/project/pycaret-core/#files"
-Homepage = "https://py-caret.readthedocs.io/en/latest/"
+Homepage = "https://www.pycaret.net/en/latest/"
 "Release Notes" = "https://github.com/sktime/pycaret/releases"
 Repository = "https://github.com/sktime/pycaret"
 


### PR DESCRIPTION
Updates links to docs to point to `www.pycaret.net` (the webpage where the docs are now hosted).