### PR TITLE
[MNT] restructure CI: conditional PR jobs, move full runs to weekly test-all workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,43 @@ jobs:
           echo "notebooks=$notebooks"
 
   # JOBS MUST START WITH test !!!!
+  test-core:
+    name: Test core dependency set
+    needs: detect
+    if: ${{ needs.detect.outputs.pycaret == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: 'pip' # caching pip dependencies
+      - name: Install core dependencies only
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U uv
+          python -m uv pip install . pytest pytest-timeout
+      - name: Python version and dependency list
+        run: |
+          python --version
+          which python
+          pip list
+      - name: Check module imports with core install
+        run: |
+          python -c "
+          import pycaret
+          import pycaret.anomaly
+          import pycaret.classification
+          import pycaret.clustering
+          import pycaret.datasets
+          import pycaret.regression
+          import pycaret.time_series
+          "
+      - name: Test with pytest
+        run: pytest --durations=0 -m "not (benchmark or plotting or tuning_random or tuning_grid)"
+
   test-notebooks-regression:
     name: Test notebook (Regression)
     needs: detect

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -1,17 +1,15 @@
-name: pycaret
+name: test all
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  schedule:
+    - cron: "0 5 * * 0"
+  workflow_dispatch:
 
 jobs:
   code-quality:
+    # guard so scheduled runs do not execute on forks;
+    # workflow_dispatch is allowed everywhere so the workflow can be tested manually
+    if: ${{ github.repository == 'sktime/pycaret' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     name: Code quality checks
     steps:
@@ -33,60 +31,9 @@ jobs:
           path: pycaret tests
           flake8-version: 7.1.1
 
-  detect:
-    name: Detect changes
-    needs: code-quality
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      pycaret: ${{ steps.filter.outputs.pycaret }}
-      notebooks: ${{ steps.filter.outputs.notebooks }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # needed to diff against the base branch
-      - id: filter
-        name: Detect changed files
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            # on push to main, always run everything
-            echo "pycaret=true" >> "$GITHUB_OUTPUT"
-            echo "notebooks=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # compare against the merge base with the PR target branch
-          BASE=$(git merge-base HEAD origin/${{ github.base_ref }})
-          echo "Comparing against $BASE"
-
-          changed_files=$(git diff --name-only "$BASE" HEAD)
-          echo "Changed files:"
-          echo "$changed_files"
-
-          pycaret=false
-          notebooks=false
-
-          if echo "$changed_files" | grep -qE '^(pycaret/|tests/|datasets/|pyproject\.toml|setup\.cfg|\.github/workflows/)'; then
-            pycaret=true
-          fi
-
-          if echo "$changed_files" | grep -qE '^(tutorials/|pycaret/|datasets/|pyproject\.toml|\.github/workflows/)'; then
-            notebooks=true
-          fi
-
-          echo "pycaret=$pycaret" >> "$GITHUB_OUTPUT"
-          echo "notebooks=$notebooks" >> "$GITHUB_OUTPUT"
-
-          echo "pycaret=$pycaret"
-          echo "notebooks=$notebooks"
-
-  # JOBS MUST START WITH test !!!!
   test-notebooks-regression:
     name: Test notebook (Regression)
-    needs: detect
-    if: ${{ needs.detect.outputs.notebooks == 'true' }}
+    needs: code-quality
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -120,8 +67,7 @@ jobs:
 
   test-notebooks:
     name: Test notebooks (excluding Regression)
-    needs: detect
-    if: ${{ needs.detect.outputs.notebooks == 'true' }}
+    needs: code-quality
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -155,8 +101,7 @@ jobs:
 
   test:
     name: Full tests (py-${{ matrix.python-version }}, ${{ matrix.os }})
-    needs: detect
-    if: ${{ needs.detect.outputs.pycaret == 'true' }}
+    needs: code-quality
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
     strategy:
@@ -202,8 +147,7 @@ jobs:
 
   test-plots:
     name: Test plotting
-    needs: detect
-    if: ${{ needs.detect.outputs.pycaret == 'true' }}
+    needs: code-quality
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
@@ -243,8 +187,7 @@ jobs:
 
   test-tune:
     name: Test tuning
-    needs: detect
-    if: ${{ needs.detect.outputs.pycaret == 'true' }}
+    needs: code-quality
     timeout-minutes: 90
     runs-on: ubuntu-latest
     strategy:
@@ -282,3 +225,44 @@ jobs:
           pip list
       - name: Test with pytest
         run: pytest --durations=0 -m "tuning_random or tuning_grid"
+
+  test-benchmarks:
+    name: Benchmark tests
+    needs: code-quality
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip' # caching pip dependencies
+      - name: Install dependencies
+        # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
+        # pyLDAvis 3.3.1 having an "sklearn" dependency
+        run: |
+          export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+          python -m pip install -U pip
+          python -m pip install -U uv
+          python -m uv pip install -U pytest numpy
+
+          # https://github.com/yaml/pyyaml/issues/736
+          echo 'Cython < 3.0' > /tmp/constraint.txt
+          PIP_BUILD_CONSTRAINT=/tmp/constraint.txt pip wheel PyYAML==5.4.1
+
+          python -m uv pip install ".[full, test]"
+          if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
+      - name: Python version and dependency list
+        run: |
+          echo "Python version expected: ${{ matrix.python-version }}"
+          python --version
+          which python
+          pip list
+      - name: Run benchmarks
+        run: pytest --durations=0 -m "benchmark"

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,13 @@ per-file-ignores =
     tests/test_time_series_mlflow.py: F841
     # Module level import not at top of file (intentional - after pytest.importorskip)
     tests/test_clustering_engines.py: E402
+    tests/test_anomaly.py: E402
+    tests/test_classification.py: E402
+    tests/test_classification_parallel.py: E402
+    tests/test_clustering.py: E402
+    tests/test_persistence.py: E402
+    tests/test_regression.py: E402
+    tests/test_time_series_parallel.py: E402
 
 [tool:pytest]
 testpaths = tests/

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -2,6 +2,9 @@ import uuid
 
 import pandas as pd
 import pytest
+
+pytest.importorskip("mlflow")
+
 from mlflow.tracking import MlflowClient
 
 import pycaret.anomaly

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -2,6 +2,9 @@ import uuid
 
 import pandas as pd
 import pytest
+
+pytest.importorskip("mlflow")
+
 from mlflow.tracking import MlflowClient
 from sklearn.metrics import recall_score
 

--- a/tests/test_classification_parallel.py
+++ b/tests/test_classification_parallel.py
@@ -1,4 +1,7 @@
 import pandas as pd
+import pytest
+
+pytest.importorskip("fugue")
 
 import pycaret.classification as pc
 from pycaret.datasets import get_data

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -3,6 +3,9 @@ import uuid
 
 import pandas as pd
 import pytest
+
+pytest.importorskip("mlflow")
+
 from mlflow.tracking import MlflowClient
 
 import pycaret.clustering

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,7 +1,11 @@
 import os
 
-import boto3
 import pytest
+
+pytest.importorskip("boto3")
+pytest.importorskip("moto")
+
+import boto3
 from moto import mock_aws
 
 from pycaret.internal.persistence import deploy_model, load_model

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -7,6 +7,7 @@ Description: Unit tests for pipeline.py
 
 """
 import io
+from importlib.util import find_spec
 
 import numpy as np
 import pandas as pd
@@ -237,7 +238,20 @@ def test_simple_categorical_imputation(imputation_method):
 
 
 @pytest.mark.parametrize("dtypes_to_select", ("mixed", "num_only", "cat_only"))
-@pytest.mark.parametrize("imputer", ("catboost", "lightgbm", "rf", "lr"))
+@pytest.mark.parametrize(
+    "imputer",
+    (
+        pytest.param(
+            "catboost",
+            marks=pytest.mark.skipif(
+                find_spec("catboost") is None, reason="catboost not installed"
+            ),
+        ),
+        "lightgbm",
+        "rf",
+        "lr",
+    ),
+)
 def test_iterative_imputer(dtypes_to_select, imputer):
     """Test iterative imputer"""
     data = pycaret.datasets.get_data("juice")

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -3,6 +3,9 @@ import uuid
 import numpy as np
 import pandas as pd
 import pytest
+
+pytest.importorskip("mlflow")
+
 from mlflow.tracking import MlflowClient
 
 import pycaret.datasets

--- a/tests/test_time_series_parallel.py
+++ b/tests/test_time_series_parallel.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.importorskip("fugue")
+
 import pycaret.time_series as pt
 from pycaret.datasets import get_data
 from pycaret.parallel import FugueBackend


### PR DESCRIPTION
#### Reference Issues/PRs

Follows the CI design of `sktime` (conditional PR jobs + scheduled full runs).

#### What does this implement/fix? Explain your changes.

Restructures CI into a lean PR workflow and a weekly full workflow:

- New `test_all.yml`: runs the weekly cron (Sun 05:00 UTC) and `workflow_dispatch`, runs the full job set including benchmarks. Scheduled runs are only on `sktime/pycaret`.

- `test.yml` (PR CI): cron is removed, `test-benchmarks` are moved to weekly-only, and a new `detect` job diffs the PR against its merge base and skips test jobs when no relevant files changed (e.g. docs-only PRs run only code-quality). Skipped jobs still report a status, so required checks stay satisfied. Pushes to `main` always run everything.

- New `test-core` job: installs pycaret with core dependencies only (no `[full]`) and checks that all modules import and the test suite passes without soft dependencies. Supporting test changes: `pytest.importorskip` guards in 7 test files that imported soft dependencies (`mlflow`, `fugue`, `boto3`/`moto`) at module level, and a skip for the `catboost` iterative imputer cases when `catboost` is not installed.

#### Does your contribution introduce a new dependency? If yes, which one?

No.
