### PR TITLE
[MNT] exclude non-package folders in release wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,4 +256,4 @@ requires = [
 ]
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*"]
+include = ["pycaret", "pycaret.*"]


### PR DESCRIPTION
Removes non-package folders from the release wheels, minimizing the size of the package.