### PR TITLE
[MNT] replace black, flake8, and isort with ruff

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,11 +31,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -46,7 +46,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -60,4 +60,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,21 +19,16 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
-      - name: Run black
-        uses: psf/black@stable
+      - name: Run ruff lint and import checks
+        uses: astral-sh/ruff-action@v3
         with:
-          src: pycaret tests
-          version: 24.8.0
-      - name: Check imports
-        uses: jamescurtin/isort-action@master
+          version: 0.16.5
+          args: check --output-format=github
+      - name: Run ruff format check
+        uses: astral-sh/ruff-action@v3
         with:
-          sort-paths: pycaret tests
-          isort-version: 5.13.2
-      - name: Run flake8
-        uses: py-actions/flake8@v2
-        with:
-          path: pycaret tests
-          flake8-version: 7.1.1
+          version: 0.16.5
+          args: format --check --diff
 
   # JOBS MUST START WITH test !!!!
   test-docs-build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     name: Code quality checks
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Run ruff lint and import checks
         uses: astral-sh/ruff-action@v3
         with:
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: 'pip' # caching pip dependencies
@@ -56,9 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: 'pip' # caching pip dependencies
@@ -77,9 +77,9 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Python environment
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: 'pip' # caching pip dependencies
@@ -111,9 +111,9 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Python environment
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: 'pip' # caching pip dependencies
@@ -154,9 +154,9 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip' # caching pip dependencies
@@ -195,9 +195,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip' # caching pip dependencies
@@ -235,9 +235,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip' # caching pip dependencies
@@ -276,9 +276,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip' # caching pip dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,9 @@ ci:
   autoupdate_schedule: monthly
 
 repos:
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.5
     hooks:
-      - id: isort
-        name: isort (python)
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
-    hooks:
-    -   id: flake8
-
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contribution Guidelines
 
-Thank you for choosing to contribute in PyCaret. There are a ton of great open-source projects out there, so we appreciate your interest in contributing to PyCaret. 
+Thank you for choosing to contribute in PyCaret. There are a ton of great open-source projects out there, so we appreciate your interest in contributing to PyCaret.
 
 # Documentation
 There is always a room for improvement in documentation. We welcome all the pull requests to fix typo / improve grammar or semantic structuring of documents. Here are few documents you can work on:
 
-- [Official Documentation](https://github.com/sktime/pycaret-docs) 
+- [Official Documentation](https://github.com/sktime/pycaret-docs)
 - [Tutorials](https://github.com/sktime/pycaret/tree/main/tutorials)
 - [Docstrings](https://www.pycaret.net/en/stable/)
 
@@ -19,10 +19,10 @@ Follow [installation instructions](https://www.pycaret.net/en/latest/installatio
 pip install -e .[test]
 ```
 
-We use [black](https://github.com/psf/black) (version `22.12.0`) and [isort](https://github.com/PyCQA/isort) (latest version)
-for code formatting. Make sure to run `isort pycaret` and `black pycaret`
-from the home directory before creating the PR. Failing to do so can result
-in a failed build, which would prevent the adoption of your code.
+We use [ruff](https://docs.astral.sh/ruff/) for linting, import sorting, and code
+formatting. Run `ruff check --fix` and `ruff format` from the home directory
+before you create the pull request. Code that is not formatted fails the build,
+which would prevent the adoption of your code.
 
 
 # Unit testing

--- a/README.md
+++ b/README.md
@@ -111,11 +111,13 @@ docker run -p 8888:8888 pycaret/full
 
 # loading sample dataset
 from pycaret.datasets import get_data
-data = get_data('juice')
+
+data = get_data("juice")
 
 # init setup
 from pycaret.classification import *
-s = setup(data, target = 'Purchase', session_id = 123)
+
+s = setup(data, target="Purchase", session_id=123)
 
 # model training and selection
 best = compare_models()
@@ -127,11 +129,11 @@ evaluate_model(best)
 pred_holdout = predict_model(best)
 
 # predict on new data
-new_data = data.copy().drop('Purchase', axis = 1)
-predictions = predict_model(best, data = new_data)
+new_data = data.copy().drop("Purchase", axis=1)
+predictions = predict_model(best, data=new_data)
 
 # save model
-save_model(best, 'best_pipeline')
+save_model(best, "best_pipeline")
 ```
 
 ### 2. OOP API
@@ -141,12 +143,14 @@ save_model(best, 'best_pipeline')
 
 # loading sample dataset
 from pycaret.datasets import get_data
-data = get_data('juice')
+
+data = get_data("juice")
 
 # init setup
 from pycaret.classification import ClassificationExperiment
+
 s = ClassificationExperiment()
-s.setup(data, target = 'Purchase', session_id = 123)
+s.setup(data, target="Purchase", session_id=123)
 
 # model training and selection
 best = s.compare_models()
@@ -158,11 +162,11 @@ s.evaluate_model(best)
 pred_holdout = s.predict_model(best)
 
 # predict on new data
-new_data = data.copy().drop('Purchase', axis = 1)
-predictions = s.predict_model(best, data = new_data)
+new_data = data.copy().drop("Purchase", axis=1)
+predictions = s.predict_model(best, data=new_data)
 
 # save model
-s.save_model(best, 'best_pipeline')
+s.save_model(best, "best_pipeline")
 ```
 
 

--- a/pycaret/containers/models/time_series.py
+++ b/pycaret/containers/models/time_series.py
@@ -303,8 +303,8 @@ class NaiveContainer(TimeSeriesContainer):
         tune_distributions = self._set_tune_distributions
         leftover_parameters_to_categorical_distributions(tune_grid, tune_distributions)
 
-        eq_function = (
-            lambda x: type(x) is NaiveForecaster
+        eq_function = lambda x: (
+            type(x) is NaiveForecaster
             and x.sp == 1
             and (x.strategy == "last" or x.strategy == "drift")
         )
@@ -364,10 +364,8 @@ class GrandMeansContainer(TimeSeriesContainer):
         tune_distributions = self._set_tune_distributions
         leftover_parameters_to_categorical_distributions(tune_grid, tune_distributions)
 
-        eq_function = (
-            lambda x: type(x) is NaiveForecaster
-            and x.sp == 1
-            and (x.strategy == "mean")
+        eq_function = lambda x: (
+            type(x) is NaiveForecaster and x.sp == 1 and (x.strategy == "mean")
         )
 
         super().__init__(
@@ -1432,9 +1430,8 @@ class CdsDtContainer(TimeSeriesContainer):
         tune_distributions = self._set_tune_distributions
         leftover_parameters_to_categorical_distributions(tune_grid, tune_distributions)
 
-        eq_function = (
-            lambda x: type(x) is BaseCdsDtForecaster
-            and type(x.regressor) is regressor_class
+        eq_function = lambda x: (
+            type(x) is BaseCdsDtForecaster and type(x.regressor) is regressor_class
         )
 
         super().__init__(

--- a/pycaret/datasets.py
+++ b/pycaret/datasets.py
@@ -1,5 +1,4 @@
-"""Module to get datasets in pycaret
-"""
+"""Module to get datasets in pycaret"""
 
 from typing import Optional
 

--- a/pycaret/internal/display/display_backend.py
+++ b/pycaret/internal/display/display_backend.py
@@ -188,7 +188,7 @@ class DatabricksBackend(JupyterBackend):
 
 
 def detect_backend(
-    backend: Optional[Union[str, DisplayBackend]] = None
+    backend: Optional[Union[str, DisplayBackend]] = None,
 ) -> DisplayBackend:
     if backend is None:
         if IN_DATABRICKS:

--- a/pycaret/internal/distributions.py
+++ b/pycaret/internal/distributions.py
@@ -195,12 +195,12 @@ class IntUniformDistribution(Distribution):
         class LogUniformInteger(Integer):
             class _LogUniform(LogUniform):
                 def sample(self, domain: "Integer", spec=None, size: int = 1):
-                    assert (
-                        domain.lower > 0
-                    ), "LogUniform needs a lower bound greater than 0"
-                    assert (
-                        0 < domain.upper < float("inf")
-                    ), "LogUniform needs a upper bound greater than 0"
+                    assert domain.lower > 0, (
+                        "LogUniform needs a lower bound greater than 0"
+                    )
+                    assert 0 < domain.upper < float("inf"), (
+                        "LogUniform needs a upper bound greater than 0"
+                    )
                     logmin = np.log(domain.lower) / np.log(self.base)
                     logmax = np.log(domain.upper) / np.log(self.base)
 

--- a/pycaret/internal/logging.py
+++ b/pycaret/internal/logging.py
@@ -95,7 +95,7 @@ def get_logger() -> logging.Logger:
 
 
 def create_logger(
-    log: Union[bool, str, logging.Logger] = True
+    log: Union[bool, str, logging.Logger] = True,
 ) -> Union[logging.Logger, DummyLogger]:
     """Create and return a logger object.
 

--- a/pycaret/internal/memory.py
+++ b/pycaret/internal/memory.py
@@ -252,8 +252,9 @@ def fast_hash(obj, hash_name="xxhash", coerce_mmap=False, protocol=None):
     valid_hash_names = ("xxhash", "md5", "sha1")
     if hash_name not in valid_hash_names:
         raise ValueError(
-            "Valid options for 'hash_name' are {}. "
-            "Got hash_name={!r} instead.".format(valid_hash_names, hash_name)
+            "Valid options for 'hash_name' are {}. Got hash_name={!r} instead.".format(
+                valid_hash_names, hash_name
+            )
         )
     if "pandas" in sys.modules:
         hasher = FastPandasHasher(
@@ -370,8 +371,7 @@ class _LegacyFastMemorizedFunc(MemorizedFunc):
             if self._verbose > 10:
                 _, name = get_func_name(self.func)
                 self.warn(
-                    "Computing func {0}, argument hash {1} "
-                    "in location {2}".format(
+                    "Computing func {0}, argument hash {1} in location {2}".format(
                         name,
                         args_id,
                         self.store_backend.get_cached_func_info([func_id])["location"],
@@ -398,8 +398,9 @@ class _LegacyFastMemorizedFunc(MemorizedFunc):
                 # XXX: Should use an exception logger
                 _, signature = format_signature(self.func, *args, **kwargs)
                 self.warn(
-                    "Exception while loading results for "
-                    "{}\n {}".format(signature, traceback.format_exc())
+                    "Exception while loading results for {}\n {}".format(
+                        signature, traceback.format_exc()
+                    )
                 )
 
                 must_call = True

--- a/pycaret/internal/persistence.py
+++ b/pycaret/internal/persistence.py
@@ -228,7 +228,6 @@ def deploy_model(
         try:
             _create_container_azure(container_name)
             _upload_blob_azure(container_name, filename, key)
-            del container_client
         except Exception:
             _upload_blob_azure(container_name, filename, key)
 

--- a/pycaret/internal/pycaret_experiment/supervised_experiment.py
+++ b/pycaret/internal/pycaret_experiment/supervised_experiment.py
@@ -2530,11 +2530,11 @@ class _SupervisedExperiment(_TabularExperiment):
                 ):
                     if "actual_estimator__n_estimators" in param_grid:
                         if custom_grid is None:
-                            extra_params[
-                                "actual_estimator__n_estimators"
-                            ] = pipeline_with_model.get_params()[
-                                "actual_estimator__n_estimators"
-                            ]
+                            extra_params["actual_estimator__n_estimators"] = (
+                                pipeline_with_model.get_params()[
+                                    "actual_estimator__n_estimators"
+                                ]
+                            )
                             param_grid.pop("actual_estimator__n_estimators")
                         else:
                             raise ValueError(

--- a/pycaret/internal/pycaret_experiment/tabular_experiment.py
+++ b/pycaret/internal/pycaret_experiment/tabular_experiment.py
@@ -2481,9 +2481,7 @@ EXPOSE {PORT}
 
 CMD ["uvicorn", "{API_NAME}:app", "--host", "0.0.0.0", "--port", "{PORT}"]
 
-""".format(
-            BASE_IMAGE=base_image, PORT=expose_port, API_NAME=api_name
-        )
+""".format(BASE_IMAGE=base_image, PORT=expose_port, API_NAME=api_name)
 
         with open("Dockerfile", "w") as f:
             f.write(docker)

--- a/pycaret/time_series/forecasting/functional.py
+++ b/pycaret/time_series/forecasting/functional.py
@@ -2,8 +2,7 @@
 # Contributors (https://github.com/sktime/pycaret/graphs/contributors)
 
 
-"""Functional API for Time Series Forecasting Experiment
-"""
+"""Functional API for Time Series Forecasting Experiment"""
 
 import logging
 import os

--- a/pycaret/time_series/forecasting/oop.py
+++ b/pycaret/time_series/forecasting/oop.py
@@ -1086,8 +1086,7 @@ class TSForecastingExperiment(_TSSupervisedExperiment, TSForecastingPreprocessor
                 # Even if there are no explicit exogenous variables, we can create
                 # them using index. Hence, we do not include the exogenous_present
                 # check here.
-                self.fe_exogenous
-                is not None
+                self.fe_exogenous is not None
             )
         ):
             self.preprocess = True

--- a/pycaret/utils/generic.py
+++ b/pycaret/utils/generic.py
@@ -593,7 +593,7 @@ def _calculate_metric(
 
 
 def normalize_custom_transformers(
-    transformers: Union[Any, Tuple[str, Any], List[Any], List[Tuple[str, Any]]]
+    transformers: Union[Any, Tuple[str, Any], List[Any], List[Tuple[str, Any]]],
 ) -> list:
     if isinstance(transformers, dict):
         transformers = list(transformers.items())
@@ -1149,7 +1149,7 @@ def check_metric(
 
 
 def _get_metrics_dict(
-    metrics_dict: Dict[str, Union[str, _Scorer]]
+    metrics_dict: Dict[str, Union[str, _Scorer]],
 ) -> Dict[str, _Scorer]:
     """Returns a metrics dictionary in which all values are callables
     of type _PredictScorer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,9 +150,7 @@ full = [
   "fugue[dask]",
   "dash[testing]",
   "dash-bootstrap-components<2.0.0",
-  "black>=24.8.0",
-  "isort>=5.13.2",
-  "flake8>=7.1.1",
+  "ruff>=0.16.5",
   "setuptools>=71.1.0",
   "mypy>=1.0.0",
 ]
@@ -214,9 +212,7 @@ prophet = [
 
 # dev - the developer dependency set, for contributors
 dev = [
-  "black>=24.8.0",
-  "isort>=5.13.2",
-  "flake8>=7.1.1",
+  "ruff>=0.16.5",
   "setuptools>=71.1.0",
   "mypy>=1.0.0",
 ]
@@ -258,3 +254,33 @@ requires = [
 
 [tool.setuptools.packages.find]
 include = ["pycaret", "pycaret.*"]
+
+[tool.ruff]
+line-length = 88
+# tutorial notebooks use `import *` by design and need their own rule set;
+# see https://github.com/sktime/pycaret/issues/99
+extend-exclude = ["*.ipynb"]
+
+[tool.ruff.lint]
+# default rule set (pycodestyle errors, pyflakes) plus isort
+select = ["E4", "E7", "E9", "F", "I"]
+ignore = [
+  # Assign a lambda expression
+  "E731",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Imported but unused
+"__init__.py" = ["F401"]
+"pycaret/distributions.py" = ["F401"]
+"pycaret/internal/preprocess/iterative_imputer.py" = ["F401"]
+"pycaret/internal/display/display_backend.py" = ["F401"]
+# Redefinition of unused imports
+"pycaret/containers/models/classification.py" = ["F811"]
+"pycaret/containers/models/clustering.py" = ["F811"]
+"pycaret/containers/models/regression.py" = ["F811"]
+"pycaret/containers/models/time_series.py" = ["F811"]
+# Local variable is assigned to but never used
+"tests/test_time_series_mlflow.py" = ["F841"]
+# Module level import not at top of file (intentional - after pytest.importorskip)
+"tests/test_clustering_engines.py" = ["E402"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,34 +1,3 @@
-[isort]
-profile = black
-
-[flake8]
-# TODO: Back to 89
-max-line-length = 300
-ignore =
-    # Assign a lambda expression
-    E731  
-    # Line break before binary operator
-    W503  
-    # Invalid escape sequence (/ in docstrings)
-    W605  
-    # Whitespace before ':' (due to black)
-    E203  
-per-file-ignores =
-    # Imported but unused
-    __init__.py: F401
-    pycaret/distributions.py: F401
-    pycaret/internal/preprocess/iterative_imputer.py: F401
-    pycaret/internal/display/display_backend.py: F401
-    # Redefinition of unused imports
-    pycaret/containers/models/classification.py: F811
-    pycaret/containers/models/clustering.py: F811
-    pycaret/containers/models/regression.py: F811
-    pycaret/containers/models/time_series.py: F811
-    # Local variable is assigned to but never used
-    tests/test_time_series_mlflow.py: F841
-    # Module level import not at top of file (intentional - after pytest.importorskip)
-    tests/test_clustering_engines.py: E402
-
 [tool:pytest]
 testpaths = tests/
 python_files = *.py

--- a/tests/benchmarks/test_memory_performance.py
+++ b/tests/benchmarks/test_memory_performance.py
@@ -1,5 +1,4 @@
-"""Module to benchmark performance of PyCaret joblib.Memory tweaks
-"""
+"""Module to benchmark performance of PyCaret joblib.Memory tweaks"""
 
 import gc
 import os

--- a/tests/benchmarks/test_time_series_sp_detection.py
+++ b/tests/benchmarks/test_time_series_sp_detection.py
@@ -1,5 +1,4 @@
-"""Module to benchmark auto detection of time series seasonal period
-"""
+"""Module to benchmark auto detection of time series seasonal period"""
 
 import pytest
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -171,7 +171,7 @@ def test_hash_memmap(tmpdir, coerce_mmap):
 # This is also skipped in joblib tests.
 @pytest.mark.skipif(
     sys.platform == "win32",
-    reason="This test is not stable under windows" " for some reason",
+    reason="This test is not stable under windows for some reason",
 )
 def test_hash_numpy_performance():
     rnd = np.random.RandomState(0)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -6,6 +6,7 @@ Author: Mavs
 Description: Unit tests for pipeline.py
 
 """
+
 import io
 
 import numpy as np

--- a/tests/test_supervised_predict_model.py
+++ b/tests/test_supervised_predict_model.py
@@ -47,9 +47,9 @@ def test_classification_predict_model():
     assert all(item in predictions.columns for item in unseen_data.columns)
 
     # Check that all metrics are valid
-    assert all(
-        metrics[metric][0] is not None for metric in metrics.columns
-    ), "Some metrics are None or invalid"
+    assert all(metrics[metric][0] is not None for metric in metrics.columns), (
+        "Some metrics are None or invalid"
+    )
 
     predictions = pycaret.classification.predict_model(lr_model)
     metrics = pycaret.classification.pull()

--- a/tests/test_time_series_base.py
+++ b/tests/test_time_series_base.py
@@ -1,5 +1,4 @@
-"""Module to test time_series functionality
-"""
+"""Module to test time_series functionality"""
 
 import numpy as np
 import pandas as pd

--- a/tests/test_time_series_blending.py
+++ b/tests/test_time_series_blending.py
@@ -117,12 +117,12 @@ def test_blend_model_predict(load_setup, load_models):
     # Prediction for some methods should not be impacted by weights
     # e.g. min, max
     # -------------------------------------------------------------------------#
-    assert np.array_equal(
-        min_blender_pred, min_blender_w_wts_pred
-    ), "min blender predictions with and without weights are not the same"
-    assert np.array_equal(
-        max_blender_pred, max_blender_w_wts_pred
-    ), "max blender predictions with and without weights are not the same"
+    assert np.array_equal(min_blender_pred, min_blender_w_wts_pred), (
+        "min blender predictions with and without weights are not the same"
+    )
+    assert np.array_equal(max_blender_pred, max_blender_w_wts_pred), (
+        "max blender predictions with and without weights are not the same"
+    )
 
 
 def test_blend_model_custom_folds(load_pos_and_neg_data):

--- a/tests/test_time_series_engines.py
+++ b/tests/test_time_series_engines.py
@@ -1,5 +1,4 @@
-"""Module to test setting of engines in time series
-"""
+"""Module to test setting of engines in time series"""
 
 from sklearn.linear_model import LinearRegression as SklearnLinearRegression
 from sktime.forecasting.arima import AutoARIMA as PmdAutoARIMA

--- a/tests/test_time_series_exogenous.py
+++ b/tests/test_time_series_exogenous.py
@@ -1,5 +1,4 @@
-"""Module to test time_series forecasting - univariate with exogenous variables
-"""
+"""Module to test time_series forecasting - univariate with exogenous variables"""
 
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore

--- a/tests/test_time_series_feat_eng.py
+++ b/tests/test_time_series_feat_eng.py
@@ -1,5 +1,4 @@
-"""Module to test time_series functionality
-"""
+"""Module to test time_series functionality"""
 
 import numpy as np
 import pytest

--- a/tests/test_time_series_metrics.py
+++ b/tests/test_time_series_metrics.py
@@ -1,5 +1,4 @@
-"""Module to test time_series functionality
-"""
+"""Module to test time_series functionality"""
 
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore

--- a/tests/test_time_series_models.py
+++ b/tests/test_time_series_models.py
@@ -1,5 +1,4 @@
-"""Module to test time_series models
-"""
+"""Module to test time_series models"""
 
 from types import SimpleNamespace
 

--- a/tests/test_time_series_plots.py
+++ b/tests/test_time_series_plots.py
@@ -1,5 +1,4 @@
-"""Module to test time_series plotting functionality
-"""
+"""Module to test time_series plotting functionality"""
 
 import os
 import sys

--- a/tests/test_time_series_preprocess.py
+++ b/tests/test_time_series_preprocess.py
@@ -1,5 +1,4 @@
-"""Module to test time_series functionality
-"""
+"""Module to test time_series functionality"""
 
 import os
 

--- a/tests/test_time_series_setup.py
+++ b/tests/test_time_series_setup.py
@@ -1,5 +1,4 @@
-"""Module to test time_series "setup" functionality
-"""
+"""Module to test time_series "setup" functionality"""
 
 import math
 

--- a/tests/test_time_series_tune_base.py
+++ b/tests/test_time_series_tune_base.py
@@ -1,5 +1,4 @@
-"""Module to test time_series "tune_model" BASE functionality
-"""
+"""Module to test time_series "tune_model" BASE functionality"""
 
 import numpy as np
 import pandas as pd

--- a/tests/test_time_series_tune_grid.py
+++ b/tests/test_time_series_tune_grid.py
@@ -1,5 +1,4 @@
-"""Module to test time_series functionality
-"""
+"""Module to test time_series functionality"""
 
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore

--- a/tests/test_time_series_tune_random.py
+++ b/tests/test_time_series_tune_random.py
@@ -1,5 +1,4 @@
-"""Module to test time_series functionality
-"""
+"""Module to test time_series functionality"""
 
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore

--- a/tests/test_time_series_utils_forecasting.py
+++ b/tests/test_time_series_utils_forecasting.py
@@ -1,5 +1,4 @@
-"""Module to test time_series forecasting utils
-"""
+"""Module to test time_series forecasting utils"""
 
 import pytest
 

--- a/tests/test_time_series_utils_forecasting_pipeline.py
+++ b/tests/test_time_series_utils_forecasting_pipeline.py
@@ -1,5 +1,4 @@
-"""Module to test time_series forecasting pipeline utils
-"""
+"""Module to test time_series forecasting pipeline utils"""
 
 import numpy as np
 import pytest

--- a/tests/test_time_series_utils_plots.py
+++ b/tests/test_time_series_utils_plots.py
@@ -1,5 +1,4 @@
-"""Module to test time_series plotting functionality
-"""
+"""Module to test time_series plotting functionality"""
 
 from typing import List
 

--- a/tests/test_utils_datetime.py
+++ b/tests/test_utils_datetime.py
@@ -1,5 +1,4 @@
-"""Module to test the datetime utility functions
-"""
+"""Module to test the datetime utility functions"""
 
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore

--- a/tests/time_series_test_utils.py
+++ b/tests/time_series_test_utils.py
@@ -1,5 +1,4 @@
-"""Helper functions for time series tests
-"""
+"""Helper functions for time series tests"""
 
 import random
 


### PR DESCRIPTION
Fixes #99.

Migrates linting, import sorting, and formatting to ruff:

- `pyproject.toml`: add the `[tool.ruff]` config and swap the lint tools for ruff in the `dev` and `full` dependency sets.
- `setup.cfg`: drop the `[isort]` and `[flake8]` sections.
- `.pre-commit-config.yaml`: replace the three hooks with `ruff-check` and `ruff-format`.
- `.github/workflows/test.yml`: run ruff in the `code-quality` job.
- `CONTRIBUTING.md`: update the formatting instructions.

The flake8 `per-file-ignores` carry over unchanged to
`[tool.ruff.lint.per-file-ignores]`. Running `ruff format` reformats 35 files,
including the Python blocks in `README.md`.

Three flake8 settings have no ruff equivalent. All three were present to stop flake8 from reporting errors on code that black had produced, so removing them loses no coverage:

- `W503`, line break before a binary operator, reports an error on every line that black wraps. It contradicts `W504`, and ruff implements neither.
- `E203`, whitespace before a colon, reports an error on the slice formatting that black produces. Ruff has this rule, but the `E2` family is not selected.
- `max-line-length = 300` worked around `E501` reporting long strings that black cannot wrap. The `E5` family is not selected either, and `line-length = 88` sets the width for `ruff format` instead.

Notebooks are the only exclusion. The notebooks under `tutorials/` use `import *`
by design and produce 562 lint findings, most of them `F405`, so covering them needs a separate PR.

### Discovered bug

The `F821` rule caught `del container_client` in
`pycaret/internal/persistence.py`, where the name is never defined. The
statement always raised `NameError`, which the `except Exception:` caught,
so `_upload_blob_azure` ran a second time on every Azure deploy. flake8 did not
catch this. This change removes the dead line, which also removes the duplicate
upload.
