### PR TITLE
[MNT] bound `statsmodels<0.15.0 until compatibility issues are fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
   "schemdraw==0.15",
   "plotly-resampler>=0.8.3.1",
   # Time-series
-  "statsmodels>=0.12.1",
+  "statsmodels>=0.12.1,<0.15.0",
   "sktime>=0.31.0",
   "tbats>=1.1.3",
   "pmdarima>=2.0.4; python_version<'3.13'",


### PR DESCRIPTION
This PR bounds `statsmodels<0.15.0` until compatibility issues are fixed, see #102 