### PR TITLE
[MNT] ignore `.db` files in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ dask*/
 trained_models/
 *.pkl
 tmp/
+*.db


### PR DESCRIPTION
The tests write `.db` files to the package folder which should not be committed.

These are not ignored in the current `.gitignore` on `main`, so should be added.