### PR TITLE
[BUG] fix `ccf` keyword argument for `statsmodels` 0.15 compatibility

### DIFF
--- a/pycaret/internal/plots/utils/time_series.py
+++ b/pycaret/internal/plots/utils/time_series.py
@@ -17,6 +17,7 @@ from statsmodels.tsa.seasonal import STL, seasonal_decompose
 from statsmodels.tsa.stattools import acf, ccf, pacf
 
 from pycaret.internal.logging import get_logger
+from pycaret.utils._dependencies import _check_soft_dependencies
 from pycaret.utils.generic import _resolve_dict_keys
 from pycaret.utils.time_series import TSAllowedPlotDataTypes
 
@@ -268,7 +269,12 @@ def corr_subplot(
     elif plot == "ccf":
         default_name = "CCF"
         target, exog = data
-        corr_values = ccf(target, exog, unbiased=False)
+        # statsmodels renamed `unbiased` to `adjusted` in 0.13.0 and removed
+        # the deprecated `unbiased` alias in 0.15.0
+        if _check_soft_dependencies("statsmodels>=0.13.0", severity="none"):
+            corr_values = ccf(target, exog, adjusted=False)
+        else:
+            corr_values = ccf(target, exog, unbiased=False)
         # Default, returns lags = len of data, hence limit it.
         corr_values = corr_values[: nlags + 1]
         # No upper and lower bounds available for CCF


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #102.

#### What does this implement/fix? Explain your changes.

`statsmodels` renamed the `unbiased` argument of `ccf` to `adjusted` in 0.13.0, and removed the deprecated `unbiased` alias in 0.15.0. `plot_model(plot="ccf")` therefore fails on `statsmodels` 0.15 with:

```
TypeError: ccf() got an unexpected keyword argument 'unbiased'
```

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

This does not close #102.

This PR fixes the 12 `ccf` ones. The other 10 come from `sktime`:

```
TypeError: ETSResults.simulate() got an unexpected keyword argument 'random_state'
TypeError: Unknown keyword arguments: ['random_state'].
```

Reported here: https://github.com/sktime/sktime/issues/10968

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
