### PR TITLE
[MNT] Clean up `full` dependencies extra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
           echo 'Cython < 3.0' > /tmp/constraint.txt
           PIP_BUILD_CONSTRAINT=/tmp/constraint.txt pip wheel PyYAML==5.4.1
 
-          python -m uv pip install ".[full]"
+          python -m uv pip install ".[dev,test,full]"
           python -m ipykernel install --user --name cikernel
       - name: Python version and dependency list
         run: |
@@ -127,7 +127,7 @@ jobs:
           echo 'Cython < 3.0' > /tmp/constraint.txt
           PIP_BUILD_CONSTRAINT=/tmp/constraint.txt pip wheel PyYAML==5.4.1
 
-          python -m uv pip install ".[full]"
+          python -m uv pip install ".[dev,test,full]"
           python -m ipykernel install --user --name cikernel
       - name: Python version and dependency list
         run: |
@@ -173,7 +173,7 @@ jobs:
           echo 'Cython < 3.0' > /tmp/constraint.txt
           PIP_BUILD_CONSTRAINT=/tmp/constraint.txt pip wheel PyYAML==5.4.1
 
-          python -m uv pip install ".[full, test]"
+          python -m uv pip install ".[dev,test,full]"
           if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
       - name: Python version and dependency list
         run: |
@@ -214,7 +214,7 @@ jobs:
           echo 'Cython < 3.0' > /tmp/constraint.txt
           PIP_BUILD_CONSTRAINT=/tmp/constraint.txt pip wheel PyYAML==5.4.1
 
-          python -m uv pip install ".[full, test]"
+          python -m uv pip install ".[dev,test,full]"
       - name: Python version and dependency list
         run: |
           echo "Python version expected: ${{ matrix.python-version }}"
@@ -254,7 +254,7 @@ jobs:
           echo 'Cython < 3.0' > /tmp/constraint.txt
           PIP_BUILD_CONSTRAINT=/tmp/constraint.txt pip wheel PyYAML==5.4.1
 
-          python -m uv pip install ".[full, test]"
+          python -m uv pip install ".[dev,test,full]"
           if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
       - name: Python version and dependency list
         run: |
@@ -295,7 +295,7 @@ jobs:
           echo 'Cython < 3.0' > /tmp/constraint.txt
           PIP_BUILD_CONSTRAINT=/tmp/constraint.txt pip wheel PyYAML==5.4.1
 
-          python -m uv pip install ".[full, test]"
+          python -m uv pip install ".[dev,test,full]"
           if [ -f requirements-prophet.txt ]; then pip install -r requirements-prophet.txt; fi
       - name: Python version and dependency list
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,14 +145,10 @@ full = [
   "fugue>=0.9.0",
   "flask",
   "werkzeug>=2.2,<=3.2",
-  "pytest>=8.0.0",
   "moto>=4.0.0",
   "fugue[dask]",
-  "dash[testing]",
   "dash-bootstrap-components<3.0.0",
-  "ruff>=0.16.5",
   "setuptools>=71.1.0",
-  "mypy>=1.0.0",
 ]
 
 analysis = [
@@ -212,9 +208,8 @@ prophet = [
 
 # dev - the developer dependency set, for contributors
 dev = [
-  "ruff>=0.16.5",
-  "setuptools>=71.1.0",
-  "mypy>=1.0.0",
+  "ruff<0.17",
+  "mypy>=1,<2.4",
 ]
 
 # docs - the dependency set used for doc build


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Packages like pytest, dash[testing], ruff, or mypy should not be
installed if users are requesting installation of pycaret-core[full]
on an average day.
