### PR TITLE
[ENH] Improve dataset loading

### DIFF
--- a/tests/benchmarks/test_memory_performance.py
+++ b/tests/benchmarks/test_memory_performance.py
@@ -23,7 +23,7 @@ pytestmark = [
 ]
 
 
-data_df = get_data(verbose=False)
+data_df = get_data("index", verbose=False, save_copy=True)
 supervised_datasets_df = data_df.copy()
 supervised_datasets_df["Items"] = (
     supervised_datasets_df["# Instances"] * supervised_datasets_df["# Attributes"]
@@ -68,7 +68,7 @@ def _test_synthetic_data(data, repeats: int = 100):
 
 
 def _test_real_data(data_name: str, repeats: int = 20):
-    data = get_data(data_name, verbose=False)
+    data = get_data(data_name, verbose=False, save_copy=True)
     globals_with_data = globals().copy()
     globals_with_data["data"] = data
     pycaret_joblib_time = min(
@@ -131,9 +131,9 @@ def _test_e2e_timeit(
     data_name: pd.DataFrame, task: str, target: str, memory_dir: str, repeats: int = 3
 ):
     globals_with_data = globals().copy()
-    globals_with_data["data"] = get_data(data_name, verbose=False).dropna(
-        subset=[target]
-    )
+    globals_with_data["data"] = get_data(
+        data_name, verbose=False, save_copy=True
+    ).dropna(subset=[target])
     globals_with_data["task"] = task
     globals_with_data["target"] = target
     globals_with_data["memory_dir"] = os.path.join(memory_dir, "joblib")

--- a/tests/benchmarks/test_time_series_sp_detection.py
+++ b/tests/benchmarks/test_time_series_sp_detection.py
@@ -33,7 +33,9 @@ def test_benchmark_sp_to_use_using_auto(
     """Benchmark auto detection of seasonal periods. Any future changes must
     beat this benchmark."""
 
-    properties = get_data("index", folder="time_series/seasonal", verbose=False)
+    properties = get_data(
+        "index", folder="time_series/seasonal", verbose=False, save_copy=True
+    )
 
     candidate_sps = []
 
@@ -47,7 +49,9 @@ def test_benchmark_sp_to_use_using_auto(
 
     exp = TSForecastingExperiment()
     for _, (index, _) in enumerate(properties[["index", "s"]].values):
-        y = get_data(index, folder="time_series/seasonal", verbose=False)
+        y = get_data(
+            index, folder="time_series/seasonal", verbose=False, save_copy=True
+        )
         exp.setup(data=y, harmonic_order_method=harmonic_order_method, session_id=index)
         candidate_sps.append(exp.candidate_sps)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,14 +33,14 @@ def reset_experiments():
 @pytest.fixture(scope="session", name="load_pos_data")
 def load_pos_data():
     """Load Pycaret Airline dataset."""
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     return data
 
 
 @pytest.fixture(scope="session", name="load_pos_and_neg_data")
 def load_pos_and_neg_data():
     """Load Pycaret Airline dataset (with some negative values)."""
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     data = data - 400  # simulate negative values
     return data
 
@@ -48,7 +48,7 @@ def load_pos_and_neg_data():
 @pytest.fixture(scope="session", name="load_uni_exo_data_target")
 def load_uni_exo_data_target():
     """Load Pycaret Univariate data with exogenous variables."""
-    data = get_data("uschange")
+    data = get_data("uschange", save_copy=True)
     target = "Consumption"
     return data, target
 
@@ -56,7 +56,7 @@ def load_uni_exo_data_target():
 @pytest.fixture(scope="session", name="load_uni_exo_data_target_positive")
 def load_uni_exo_data_target_positive():
     """Load Pycaret Univariate data with exogenous variables (strictly positive)."""
-    data = get_data("uschange")
+    data = get_data("uschange", save_copy=True)
     data = data.clip(lower=0.1)
     target = "Consumption"
     return data, target
@@ -65,7 +65,7 @@ def load_uni_exo_data_target_positive():
 @pytest.fixture(scope="session", name="load_pos_data_missing")
 def load_pos_data_missing():
     """Load Pycaret Airline dataset (with missing values)."""
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     remove_n = int(0.4 * len(data))
     np.random.seed(42)
     na_indices = np.random.choice(data.index, remove_n, replace=False)
@@ -76,7 +76,7 @@ def load_pos_data_missing():
 @pytest.fixture(scope="session", name="load_pos_and_neg_data_missing")
 def load_pos_and_neg_data_missing():
     """Load Pycaret Airline dataset (with some negative & missing values)."""
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     data = data - 400  # simulate negative values
     data[10:20] = np.nan  # In train with FH = 12
     data[-5:-2] = np.nan  # In test with FH = 12
@@ -86,7 +86,7 @@ def load_pos_and_neg_data_missing():
 @pytest.fixture(scope="session", name="load_uni_exo_data_target_missing")
 def load_uni_exo_data_target_missing():
     """Load Pycaret Univariate data with exogenous variables & missing values."""
-    data = get_data("uschange")
+    data = get_data("uschange", save_copy=True)
     data[10:20] = np.nan  # In train with FH = 12
     data[-5:-2] = np.nan  # In test with FH = 12
     target = "Consumption"

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -10,7 +10,7 @@ import pycaret.datasets
 
 @pytest.fixture(scope="module")
 def data():
-    return pycaret.datasets.get_data("anomaly")
+    return pycaret.datasets.get_data("anomaly", save_copy=True)
 
 
 def test_anomaly(data):

--- a/tests/test_check_drift.py
+++ b/tests/test_check_drift.py
@@ -9,7 +9,7 @@ import pycaret.datasets
 
 def test_check_drift(tmpdir):
     # loading dataset
-    data = pycaret.datasets.get_data("blood")
+    data = pycaret.datasets.get_data("blood", save_copy=True)
     experiment = pycaret.classification.ClassificationExperiment()
 
     # initialize setup
@@ -27,7 +27,7 @@ def test_check_drift(tmpdir):
 
 def test_check_drift_no_setup(tmpdir):
     # loading dataset
-    data = pycaret.datasets.get_data("blood")
+    data = pycaret.datasets.get_data("blood", save_copy=True)
     reference_data, current_data = train_test_split(data, test_size=0.2, shuffle=False)
     experiment = pycaret.classification.ClassificationExperiment()
 

--- a/tests/test_check_fairness.py
+++ b/tests/test_check_fairness.py
@@ -7,7 +7,7 @@ import pycaret.regression
 
 def test_check_fairness_binary_classification():
     # loading dataset
-    data = pycaret.datasets.get_data("income")
+    data = pycaret.datasets.get_data("income", save_copy=True)
 
     # initialize setup
     pycaret.classification.setup(
@@ -27,7 +27,7 @@ def test_check_fairness_binary_classification():
 
 def test_check_fairness_multiclass_classification():
     # loading dataset
-    data = pycaret.datasets.get_data("iris")
+    data = pycaret.datasets.get_data("iris", save_copy=True)
 
     # initialize setup
     pycaret.classification.setup(
@@ -50,7 +50,7 @@ def test_check_fairness_multiclass_classification():
 
 def test_check_fairness_regression():
     # loading dataset
-    data = pycaret.datasets.get_data("boston")
+    data = pycaret.datasets.get_data("boston", save_copy=True)
 
     # initialize setup
     pycaret.regression.setup(

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -12,7 +12,7 @@ import pycaret.datasets
 @pytest.fixture(scope="module")
 def juice_dataframe():
     # loading dataset
-    return pycaret.datasets.get_data("juice")
+    return pycaret.datasets.get_data("juice", save_copy=True)
 
 
 @pytest.mark.parametrize("return_train_score", [True, False])
@@ -204,7 +204,7 @@ class TestClassificationExperimentCustomTags:
         with pytest.raises(Exception):
             # init setup
             _ = pycaret.classification.setup(
-                pycaret.datasets.get_data("juice"),
+                pycaret.datasets.get_data("juice", save_copy=True),
                 target="Purchase",
                 remove_multicollinearity=True,
                 multicollinearity_threshold=0.95,

--- a/tests/test_classification_engines.py
+++ b/tests/test_classification_engines.py
@@ -8,7 +8,7 @@ import pycaret.datasets
 def test_engines_setup_global_args():
     """Tests the setting of engines using global arguments in setup."""
 
-    juice_dataframe = pycaret.datasets.get_data("juice")
+    juice_dataframe = pycaret.datasets.get_data("juice", save_copy=True)
     exp = pycaret.classification.ClassificationExperiment()
 
     # init setup
@@ -36,7 +36,7 @@ def test_engines_setup_global_args():
 def test_engines_global_methods():
     """Tests the setting of engines using methods like set_engine (global changes)."""
 
-    juice_dataframe = pycaret.datasets.get_data("juice")
+    juice_dataframe = pycaret.datasets.get_data("juice", save_copy=True)
     exp = pycaret.classification.ClassificationExperiment()
 
     # init setup
@@ -64,7 +64,7 @@ def test_engines_global_methods():
 def test_create_model_engines_local_args():
     """Tests the setting of engines for create_model using local args."""
 
-    juice_dataframe = pycaret.datasets.get_data("juice")
+    juice_dataframe = pycaret.datasets.get_data("juice", save_copy=True)
     exp = pycaret.classification.ClassificationExperiment()
 
     # init setup
@@ -97,7 +97,7 @@ def test_create_model_engines_local_args():
 def test_compare_models_engines_local_args():
     """Tests the setting of engines for compare_models using local args."""
 
-    juice_dataframe = pycaret.datasets.get_data("juice")
+    juice_dataframe = pycaret.datasets.get_data("juice", save_copy=True)
     exp = pycaret.classification.ClassificationExperiment()
 
     # init setup
@@ -134,7 +134,7 @@ def test_compare_models_engines_local_args():
 
 @pytest.mark.parametrize("algo", ("lr", "knn", "rbfsvm"))
 def test_sklearnex_model(algo: str):
-    juice_dataframe = pycaret.datasets.get_data("juice")
+    juice_dataframe = pycaret.datasets.get_data("juice", save_copy=True)
     exp = pycaret.classification.ClassificationExperiment()
 
     # init setup

--- a/tests/test_classification_parallel.py
+++ b/tests/test_classification_parallel.py
@@ -29,7 +29,7 @@ def test_remote_compare_models_allows_missing_report_callback(monkeypatch):
 
 def test_classification_parallel():
     pc.setup(
-        data_func=lambda: get_data("juice", verbose=False),
+        data_func=lambda: get_data("juice", verbose=False, save_copy=True),
         target="Purchase",
         session_id=0,
         n_jobs=1,
@@ -69,7 +69,7 @@ def test_classification_parallel():
 
 def test_classification_parallel_returns_empty_models_list_when_no_model_is_trained():
     pc.setup(
-        data_func=lambda: get_data("juice", verbose=False),
+        data_func=lambda: get_data("juice", verbose=False, save_copy=True),
         target="Purchase",
         session_id=0,
         n_jobs=1,

--- a/tests/test_classification_plots.py
+++ b/tests/test_classification_plots.py
@@ -13,7 +13,7 @@ matplotlib.use("Agg")
 @pytest.mark.plotting
 def test_plot():
     # loading dataset
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     assert isinstance(data, pd.DataFrame)
 
     # init setup

--- a/tests/test_classification_tuning.py
+++ b/tests/test_classification_tuning.py
@@ -18,7 +18,7 @@ if "CI" in os.environ:
 @pytest.mark.skip(reason="no way of currently testing this")
 def test_classification_tuning():
     # loading dataset
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     assert isinstance(data, pd.DataFrame)
 
     # init setup

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -14,7 +14,7 @@ if sys.platform == "win32":
 
 @pytest.fixture(scope="module")
 def data():
-    return pycaret.datasets.get_data("jewellery")
+    return pycaret.datasets.get_data("jewellery", save_copy=True)
 
 
 def test_clustering(data):

--- a/tests/test_clustering_engines.py
+++ b/tests/test_clustering_engines.py
@@ -10,7 +10,7 @@ import pycaret.datasets
 def test_engines_setup_global_args():
     """Tests the setting of engines using global arguments in setup."""
 
-    jewellery_dataframe = pycaret.datasets.get_data("jewellery")
+    jewellery_dataframe = pycaret.datasets.get_data("jewellery", save_copy=True)
     exp = pycaret.clustering.ClusteringExperiment()
 
     # init setup
@@ -38,7 +38,7 @@ def test_engines_setup_global_args():
 def test_engines_global_methods():
     """Tests the setting of engines using methods like set_engine (global changes)."""
 
-    jewellery_dataframe = pycaret.datasets.get_data("jewellery")
+    jewellery_dataframe = pycaret.datasets.get_data("jewellery", save_copy=True)
     exp = pycaret.clustering.ClusteringExperiment()
 
     # init setup
@@ -66,7 +66,7 @@ def test_engines_global_methods():
 def test_create_model_engines_local_args():
     """Tests the setting of engines for create_model using local args."""
 
-    jewellery_dataframe = pycaret.datasets.get_data("jewellery")
+    jewellery_dataframe = pycaret.datasets.get_data("jewellery", save_copy=True)
     exp = pycaret.clustering.ClusteringExperiment()
 
     # init setup
@@ -98,7 +98,7 @@ def test_create_model_engines_local_args():
 
 @pytest.mark.parametrize("algo", ("kmeans", "dbscan"))
 def test_all_sklearnex_models(algo: str):
-    jewellery_dataframe = pycaret.datasets.get_data("jewellery")
+    jewellery_dataframe = pycaret.datasets.get_data("jewellery", save_copy=True)
     exp = pycaret.clustering.ClusteringExperiment()
 
     # init setup

--- a/tests/test_convert_model.py
+++ b/tests/test_convert_model.py
@@ -5,7 +5,7 @@ import pycaret.regression
 
 def test_classification_convert_model():
     # loading dataset
-    data = pycaret.datasets.get_data("blood")
+    data = pycaret.datasets.get_data("blood", save_copy=True)
 
     # initialize setup
     pycaret.classification.setup(
@@ -25,7 +25,7 @@ def test_classification_convert_model():
 
 def test_regression_convert_model():
     # loading dataset
-    data = pycaret.datasets.get_data("boston")
+    data = pycaret.datasets.get_data("boston", save_copy=True)
 
     # initialize setup
     pycaret.regression.setup(

--- a/tests/test_create_api.py
+++ b/tests/test_create_api.py
@@ -12,7 +12,7 @@ if sys.platform == "win32":
 
 def test_classification_create_api():
     # loading dataset
-    data = pycaret.datasets.get_data("blood")
+    data = pycaret.datasets.get_data("blood", save_copy=True)
 
     # initialize setup
     pycaret.classification.setup(
@@ -32,7 +32,7 @@ def test_classification_create_api():
 
 def test_regression_create_api():
     # loading dataset
-    data = pycaret.datasets.get_data("boston")
+    data = pycaret.datasets.get_data("boston", save_copy=True)
 
     # initialize setup
     pycaret.regression.setup(

--- a/tests/test_create_app.py
+++ b/tests/test_create_app.py
@@ -5,7 +5,7 @@ import pycaret.regression
 
 def test_classification_create_app():
     # loading dataset
-    data = pycaret.datasets.get_data("blood")
+    data = pycaret.datasets.get_data("blood", save_copy=True)
 
     # initialize setup
     pycaret.classification.setup(
@@ -25,7 +25,7 @@ def test_classification_create_app():
 
 def test_regression_create_app():
     # loading dataset
-    data = pycaret.datasets.get_data("boston")
+    data = pycaret.datasets.get_data("boston", save_copy=True)
 
     # initialize setup
     pycaret.regression.setup(

--- a/tests/test_create_docker.py
+++ b/tests/test_create_docker.py
@@ -12,7 +12,7 @@ if sys.platform == "win32":
 
 def test_classification_create_docker():
     # loading dataset
-    data = pycaret.datasets.get_data("blood")
+    data = pycaret.datasets.get_data("blood", save_copy=True)
 
     # initialize setup
     pycaret.classification.setup(
@@ -33,7 +33,7 @@ def test_classification_create_docker():
 
 def test_regression_create_docker():
     # loading dataset
-    data = pycaret.datasets.get_data("boston")
+    data = pycaret.datasets.get_data("boston", save_copy=True)
 
     # initialize setup
     pycaret.regression.setup(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6,7 +6,7 @@
 
 def test_classification_dashboard():
     # loading dataset
-    # data = pycaret.datasets.get_data("blood")
+    # data = pycaret.datasets.get_data("blood", save_copy=True)
 
     # setup environment
     # pycaret.classification.setup(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -11,7 +11,7 @@ def test_datasets():
 
     # # loading dataset
     # os.chdir(os.path.dirname(os.path.realpath(__file__)))
-    # data = get_data("test_files/dummy_dataset")
+    # data = get_data("test_files/dummy_dataset", save_copy=True)
     # assert isinstance(data, pd.DataFrame)
     # rows, cols = data.shape
     # assert rows >= 1
@@ -22,14 +22,14 @@ def test_datasets():
     ##############################
 
     # loading list of datasets
-    index = get_data("index")
+    index = get_data("index", save_copy=True)
     assert isinstance(index, pd.DataFrame)
     rows, cols = index.shape
     assert rows > 1
     assert cols == 8
 
     # loading dataset
-    data = get_data("credit")
+    data = get_data("credit", save_copy=True)
     assert isinstance(data, pd.DataFrame)
     rows, cols = data.shape
     assert rows == 24000
@@ -42,14 +42,14 @@ def test_datasets():
 
     folder = "time_series/seasonal"
     # loading list of datasets
-    index = get_data("index", folder=folder)
+    index = get_data("index", folder=folder, save_copy=True)
     assert isinstance(index, pd.DataFrame)
     rows, cols = index.shape
     assert rows > 1
     assert cols == 12
 
     # loading dataset
-    data = get_data("1", folder=folder)
+    data = get_data("1", folder=folder, save_copy=True)
     assert isinstance(data, pd.DataFrame)
     rows, cols = data.shape
     assert rows >= 1
@@ -60,7 +60,7 @@ def test_datasets():
     ###########################
 
     # loading dataset
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     assert isinstance(data, pd.Series)
     rows = len(data)
     assert rows >= 1

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -387,7 +387,7 @@ class MyOwnModel(BaseEstimator):
 
 
 def test_using_custom_model():
-    insurance = get_data("insurance")
+    insurance = get_data("insurance", save_copy=True)
 
     # init setup
     reg1 = RegressionExperiment()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,7 +53,7 @@ def check_exp(exp, **kwargs):
 def test_model_equality_classification():
     exp = ClassificationExperiment()
     exp.setup(
-        pycaret.datasets.get_data("juice"),
+        pycaret.datasets.get_data("juice", save_copy=True),
         target="Purchase",
     )
     check_exp(exp, cross_validation=False)
@@ -62,7 +62,7 @@ def test_model_equality_classification():
 def test_model_equality_regression():
     exp = RegressionExperiment()
     exp.setup(
-        pycaret.datasets.get_data("boston"),
+        pycaret.datasets.get_data("boston", save_copy=True),
         target="medv",
     )
     check_exp(exp, cross_validation=False)
@@ -71,7 +71,7 @@ def test_model_equality_regression():
 def test_model_equality_time_series():
     exp = TSForecastingExperiment()
     exp.setup(
-        pycaret.datasets.get_data("airline"),
+        pycaret.datasets.get_data("airline", save_copy=True),
         fh=12,
     )
     check_exp(exp, cross_validation=False)
@@ -80,7 +80,7 @@ def test_model_equality_time_series():
 def test_model_equality_clustering():
     exp = ClusteringExperiment()
     exp.setup(
-        pycaret.datasets.get_data("jewellery"),
+        pycaret.datasets.get_data("jewellery", save_copy=True),
     )
     check_exp(exp)
 
@@ -88,7 +88,7 @@ def test_model_equality_clustering():
 def test_model_equality_anomaly(disable_numba):
     exp = AnomalyExperiment()
     exp.setup(
-        pycaret.datasets.get_data("anomaly"),
+        pycaret.datasets.get_data("anomaly", save_copy=True),
     )
     check_exp(exp)
 

--- a/tests/test_multiclass.py
+++ b/tests/test_multiclass.py
@@ -8,7 +8,7 @@ import pycaret.datasets
 @pytest.fixture(scope="module")
 def iris_dataframe():
     # loading dataset
-    return pycaret.datasets.get_data("iris")
+    return pycaret.datasets.get_data("iris", save_copy=True)
 
 
 @pytest.mark.parametrize("return_train_score", [True, False])

--- a/tests/test_optimize_threshold.py
+++ b/tests/test_optimize_threshold.py
@@ -7,7 +7,7 @@ from pycaret.internal.meta_estimators import CustomProbabilityThresholdClassifie
 
 def test_optimize_threshold():
     # loading dataset
-    data = pycaret.datasets.get_data("blood")
+    data = pycaret.datasets.get_data("blood", save_copy=True)
 
     # initialize setup
     pycaret.classification.setup(

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.abspath(".."))
 def test_overflow_gbr_lightgbm():
     from pycaret.datasets import get_data
 
-    data = get_data("boston")
+    data = get_data("boston", save_copy=True)
     from pycaret.regression import create_model, setup, tune_model
 
     setup(
@@ -31,7 +31,7 @@ def test_overflow_xgboost():
 
     from pycaret.datasets import get_data
 
-    data = get_data("boston")
+    data = get_data("boston", save_copy=True)
     from pycaret.regression import create_model, setup, tune_model
 
     setup(

--- a/tests/test_persistence_experiment.py
+++ b/tests/test_persistence_experiment.py
@@ -33,7 +33,7 @@ def check_experiment_equality(exp, new_exp):
 
 @pytest.mark.parametrize("preprocess_data", (True, False))
 def test_anomaly_persistence(tmpdir, preprocess_data):
-    data = pycaret.datasets.get_data("anomaly")
+    data = pycaret.datasets.get_data("anomaly", save_copy=True)
     exp = AnomalyExperiment()
     exp.setup(
         data,
@@ -56,7 +56,7 @@ def test_anomaly_persistence(tmpdir, preprocess_data):
 
 @pytest.mark.parametrize("preprocess_data", (True, False))
 def test_clustering_persistence(tmpdir, preprocess_data):
-    data = pycaret.datasets.get_data("jewellery")
+    data = pycaret.datasets.get_data("jewellery", save_copy=True)
     exp = ClusteringExperiment()
     exp.setup(
         data,
@@ -79,7 +79,7 @@ def test_clustering_persistence(tmpdir, preprocess_data):
 
 @pytest.mark.parametrize("preprocess_data", (True, False))
 def test_classification_persistence(tmpdir, preprocess_data):
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     exp = ClassificationExperiment()
     exp.setup(
         data,
@@ -103,7 +103,7 @@ def test_classification_persistence(tmpdir, preprocess_data):
 
 @pytest.mark.parametrize("preprocess_data", (True, False))
 def test_regression_persistence(tmpdir, preprocess_data):
-    data = pycaret.datasets.get_data("boston")
+    data = pycaret.datasets.get_data("boston", save_copy=True)
     exp = RegressionExperiment()
     exp.setup(
         data,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -19,7 +19,7 @@ from pycaret.datasets import get_data
 @pytest.fixture
 def pipeline():
     """Get a pipeline from atom with/without final estimator."""
-    dataset = get_data("juice", verbose=False)
+    dataset = get_data("juice", verbose=False, save_copy=True)
     pc = pycaret.classification.setup(
         data=dataset,
         polynomial_features=True,
@@ -32,14 +32,14 @@ def pipeline():
 
 def test_fit(pipeline):
     """Assert that the pipeline can be fitted normally."""
-    data = get_data("juice", verbose=False)
+    data = get_data("juice", verbose=False, save_copy=True)
     assert pipeline.fit(data.iloc[:, :-1], data.iloc[:, -1])
     assert isinstance(pipeline.feature_names_in_, list)
 
 
 def test_transforms_only_y():
     """Assert that the pipeline can transform the target column only."""
-    data = get_data("bank", verbose=False)
+    data = get_data("bank", verbose=False, save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         preprocess=False,
@@ -51,7 +51,7 @@ def test_transforms_only_y():
 
 def test_transform(pipeline):
     """Assert that the pipeline uses transform normally."""
-    data = get_data("juice", verbose=False)
+    data = get_data("juice", verbose=False, save_copy=True)
     pipeline.fit(data.iloc[:, :-1], data.iloc[:, -1])
     assert isinstance(pipeline.transform(data.iloc[:, :-1]), pd.DataFrame)
     assert isinstance(pipeline.transform(data.iloc[:, :-1], data.iloc[:, -1]), tuple)
@@ -59,7 +59,7 @@ def test_transform(pipeline):
 
 def test_fit_transform(pipeline):
     """Assert that the pipeline can be fit-transformed normally."""
-    data = get_data("juice", verbose=False)
+    data = get_data("juice", verbose=False, save_copy=True)
     pipeline.steps.append(("test", "passthrough"))
     X, y = pipeline.fit_transform(data.iloc[:, :-1], data.iloc[:, -1])
     assert isinstance(X, pd.DataFrame) and isinstance(y, pd.Series)
@@ -67,6 +67,6 @@ def test_fit_transform(pipeline):
 
 def test_transform_imbalancer(pipeline):
     """Assert that the pipeline ignores FixImbalancer during predicting."""
-    data = get_data("juice", verbose=False)
+    data = get_data("juice", verbose=False, save_copy=True)
     pipeline.fit(data.iloc[:, :-1], data.iloc[:, -1])
     assert len(pipeline.transform(data.iloc[:, :-1])) == len(data)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -26,21 +26,21 @@ import pycaret.regression
 
 def test_select_target_by_index():
     """Assert that the target can be selected by its column index."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(data, target=2)
     assert pc.target_param == "WeekofPurchase"
 
 
 def test_select_target_by_str():
     """Assert that the target can be selected by its column name."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(data, target="WeekofPurchase")
     assert pc.target_param == "WeekofPurchase"
 
 
 def test_nans_in_target_column():
     """Assert that the target can be selected by its column name."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     data.loc[3, "WeekofPurchase"] = np.nan
     with pytest.raises(ValueError, match=r".*missing values found.*"):
         pycaret.classification.setup(data, target="WeekofPurchase")
@@ -48,7 +48,7 @@ def test_nans_in_target_column():
 
 def test_select_target_by_sequence():
     """Assert that the target can be a sequence."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(data, target=[1] * len(data))
     assert pc.target_param == "target"
 
@@ -73,7 +73,7 @@ def test_input_is_sparse():
 
 def test_assign_index_is_false():
     """Assert that the index is reset when index=False."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     data.index = list(range(100, len(data) + 100))
     pc = pycaret.classification.setup(data, index=False)
     assert pc.dataset.index[0] == 0
@@ -81,7 +81,7 @@ def test_assign_index_is_false():
 
 def test_assign_index_is_true():
     """Assert that the index remains unchanged when index=True."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     data.index = list(range(100, len(data) + 100))
     pc = pycaret.classification.setup(
         data=data,
@@ -95,7 +95,7 @@ def test_assign_index_is_true():
 @pytest.mark.parametrize("index", [0, "Id", list(range(2, 1072))])
 def test_assign_index(index):
     """Assert that the index can be assigned."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         index=index,
@@ -108,7 +108,7 @@ def test_assign_index(index):
 
 def test_duplicate_columns():
     """Assert that an error is raised when there are duplicate columns."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     data = data.rename(columns={"Purchase": "Id"})  # Make another column named Id
     with pytest.raises(ValueError, match=".*Duplicate column names found in X.*"):
         pycaret.classification.setup(data)
@@ -116,7 +116,7 @@ def test_duplicate_columns():
 
 def test_duplicate_indices():
     """Assert that an error is raised when there are duplicate indices."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     with pytest.raises(ValueError, match=".*duplicate indices.*"):
         pycaret.classification.setup(
             data=data,
@@ -127,7 +127,7 @@ def test_duplicate_indices():
 
 def test_preprocess_is_False():
     """Assert that preprocessing is skipped when preprocess=False."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(data, preprocess=False)
     X, _ = pc.pipeline.transform(pc.X, pc.y)
     assert X["Purchase"].dtype.kind not in "ifu"  # No encoding of categorical columns
@@ -135,7 +135,7 @@ def test_preprocess_is_False():
 
 def test_ignore_features():
     """Assert that features can be ignored in preprocessing."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(data, ignore_features=["Purchase"])
     X, _ = pc.pipeline.transform(pc.X, pc.y)
     assert "Purchase" not in X
@@ -143,7 +143,7 @@ def test_ignore_features():
 
 def test_weird_chars_in_column_names():
     """Assert that weird characters from column names are dropped."""
-    data = pycaret.datasets.get_data("parkinsons")
+    data = pycaret.datasets.get_data("parkinsons", save_copy=True)
     data.columns = ["[col"] + list(data.columns[1:])
     assert "[" in data.columns[0]
 
@@ -178,7 +178,7 @@ def test_weird_chars_in_column_names_no_impact_on_other_preprocessors():
 
 def test_encode_target():
     """Assert that the target column is automatically encoded."""
-    data = pycaret.datasets.get_data("telescope")
+    data = pycaret.datasets.get_data("telescope", save_copy=True)
     pc = pycaret.classification.setup(data)
     _, y = pc.pipeline.transform(pc.X, pc.y)
     assert y.dtype.kind in "ifu"
@@ -186,7 +186,7 @@ def test_encode_target():
 
 def test_date_features():
     """Assert that features are extracted from date features."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     data["date"] = pd.date_range(start="1/1/2018", periods=len(data))
     pc = pycaret.classification.setup(data, target=-2, date_features=["date"])
     X, _ = pc.pipeline.transform(pc.X, pc.y)
@@ -195,7 +195,7 @@ def test_date_features():
 
 def test_custom_date_features():
     """Assert that features are extracted from date features."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     data["date"] = pd.date_range(start="1/1/2018", periods=len(data))
     pc = pycaret.classification.setup(
         data,
@@ -212,7 +212,7 @@ def test_custom_date_features():
 )
 def test_simple_numeric_imputation(imputation_method):
     """Assert that missing values are imputed."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     data.loc[100, "WeekofPurchase"] = np.nan
     pc = pycaret.classification.setup(
         data=data,
@@ -226,7 +226,7 @@ def test_simple_numeric_imputation(imputation_method):
 @pytest.mark.parametrize("imputation_method", ["drop", "missing", "mode"])
 def test_simple_categorical_imputation(imputation_method):
     """Assert that missing values are imputed."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     data.loc[100, "Purchase"] = np.nan
     pc = pycaret.classification.setup(
         data=data,
@@ -241,7 +241,7 @@ def test_simple_categorical_imputation(imputation_method):
 @pytest.mark.parametrize("imputer", ("catboost", "lightgbm", "rf", "lr"))
 def test_iterative_imputer(dtypes_to_select, imputer):
     """Test iterative imputer"""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     categories = {}
     for i, col in enumerate(data.columns):
         # leave two columns and target filled
@@ -280,7 +280,7 @@ def test_iterative_imputer(dtypes_to_select, imputer):
 def test_iterative_imputer_many_categories():
     """Test iterative imputer with a dataset with many categories"""
     # tests for sktime/pycaret/issues/3636
-    data = pycaret.datasets.get_data("titanic")
+    data = pycaret.datasets.get_data("titanic", save_copy=True)
     pycaret.classification.setup(
         data,
         target="Survived",
@@ -295,7 +295,7 @@ def test_iterative_imputer_many_categories():
 @pytest.mark.parametrize("embedding_method", ["bow", "tf-idf"])
 def test_text_embedding(embedding_method):
     """Assert that text columns are embedded."""
-    data = pycaret.datasets.get_data("spx")
+    data = pycaret.datasets.get_data("spx", save_copy=True)
     pc = pycaret.regression.setup(
         data=data.iloc[:50, :],  # Less rows for faster processing
         text_features=["text"],
@@ -307,7 +307,7 @@ def test_text_embedding(embedding_method):
 
 def test_encoding_ordinal_features():
     """Assert that ordinal features are encoded correctly."""
-    data = pycaret.datasets.get_data("employee")
+    data = pycaret.datasets.get_data("employee", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         imputation_type=None,
@@ -322,7 +322,7 @@ def test_encoding_ordinal_features():
 
 def test_encoding_grouping_rare_categories():
     """Assert that rare categories are grouped before encoding."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(data, rare_to_value=0.5)
     X, _ = pc.pipeline.transform(pc.X, pc.y)
     assert "rare" in pc.pipeline.steps[-1][1].transformer.mapping[0]["mapping"]
@@ -330,7 +330,7 @@ def test_encoding_grouping_rare_categories():
 
 def test_encoding_categorical_features():
     """Assert that categorical features are encoded correctly."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(data)
     X, _ = pc.pipeline.transform(pc.X, pc.y)
     assert list(sorted(X["Purchase"].unique())) == [0.0, 1.0]
@@ -338,7 +338,7 @@ def test_encoding_categorical_features():
 
 def test_encoding_categorical_features_duplicate_names():
     """Assert that no duplicate columns are created after OHE"""
-    data = pycaret.datasets.get_data("iris")
+    data = pycaret.datasets.get_data("iris", save_copy=True)
     data["species_2"] = data["species"].copy()
     data["target"] = data["species"].copy()
     pc = pycaret.classification.setup(data, target="target")
@@ -349,7 +349,7 @@ def test_encoding_categorical_features_duplicate_names():
 @pytest.mark.parametrize("transformation_method", ["yeo-johnson", "quantile"])
 def test_transformation(transformation_method):
     """Assert that features can be transformed to a gaussian distribution."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         transformation=True,
@@ -362,7 +362,7 @@ def test_transformation(transformation_method):
 @pytest.mark.parametrize("normalize_method", ["zscore", "minmax", "maxabs", "robust"])
 def test_normalize(normalize_method):
     """Assert that features can be normalized."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         normalize=True,
@@ -374,7 +374,7 @@ def test_normalize(normalize_method):
 
 def test_low_variance_threshold():
     """Assert that features with low variance are dropped."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     data["feature"] = 1  # Minimal variance
     pc = pycaret.classification.setup(
         data=data,
@@ -388,7 +388,7 @@ def test_low_variance_threshold():
 @pytest.mark.parametrize("drop_groups", (True, False))
 def test_feature_grouping(drop_groups):
     """Assert that feature groups are replaced for stats."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         target="STORE",
@@ -405,7 +405,7 @@ def test_feature_grouping(drop_groups):
 
 def test_remove_multicollinearity():
     """Assert that one of two collinear features are dropped."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     data["Id 2"] = list(range(len(data)))  # Correlated with Id
     pc = pycaret.classification.setup(
         data=data,
@@ -420,7 +420,7 @@ def test_remove_multicollinearity():
 
 def test_bin_numeric_features():
     """Assert that numeric features can be binned."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(data=data, bin_numeric_features=["Id"])
     X, _ = pc.pipeline.transform(pc.X, pc.y)
     assert X["Id"].nunique() == 5
@@ -429,7 +429,7 @@ def test_bin_numeric_features():
 @pytest.mark.parametrize("outliers_method", ["iforest", "ee", "lof"])
 def test_remove_outliers(outliers_method):
     """Assert that outliers can be removed."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         low_variance_threshold=None,
@@ -442,7 +442,7 @@ def test_remove_outliers(outliers_method):
 
 def test_polynomial_features():
     """Assert that polynomial features can be created."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         polynomial_features=True,
@@ -457,7 +457,7 @@ def test_polynomial_features():
 )
 def test_fix_imbalance(fix_imbalance_method):
     """Assert that the classes can be balanced."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         low_variance_threshold=None,
@@ -470,7 +470,7 @@ def test_fix_imbalance(fix_imbalance_method):
 @pytest.mark.parametrize("pca_method", ["linear", "kernel", "incremental"])
 def test_pca(pca_method):
     """Assert that pca can be applied."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         pca=True,
@@ -483,7 +483,7 @@ def test_pca(pca_method):
 
 def test_keep_features():
     """Assert that features are not dropped through preprocess."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         keep_features=["Id"],
@@ -497,7 +497,7 @@ def test_keep_features():
 @pytest.mark.parametrize("fs_method", ["univariate", "classic", "sequential"])
 def test_feature_selection(fs_method):
     """Assert that feature selection can be applied."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         feature_selection=True,
@@ -511,7 +511,7 @@ def test_feature_selection(fs_method):
 
 def test_feature_selection_custom_estimator():
     """Assert that feature selection can be applied using a custom estimator."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         feature_selection=True,
@@ -525,7 +525,7 @@ def test_feature_selection_custom_estimator():
 
 def test_custom_pipeline_is_list():
     """Assert that a custom pipeline can be provided as list."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         custom_pipeline=[("pca", PCA(n_components=5))],
@@ -536,7 +536,7 @@ def test_custom_pipeline_is_list():
 
 def test_custom_pipeline_is_pipeline():
     """Assert that a custom pipeline can be provided as a Pipeline object."""
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         custom_pipeline=Pipeline(
@@ -550,7 +550,7 @@ def test_custom_pipeline_is_pipeline():
 @pytest.mark.parametrize("pos", [-1, 0, 1])
 def test_custom_pipeline_positions(pos):
     """Assert that a custom pipeline can be provided at a specific position."""
-    data = pycaret.datasets.get_data("cancer")
+    data = pycaret.datasets.get_data("cancer", save_copy=True)
     pc = pycaret.classification.setup(
         data=data,
         remove_outliers=True,

--- a/tests/test_probability_threshold.py
+++ b/tests/test_probability_threshold.py
@@ -7,7 +7,7 @@ from pycaret.internal.meta_estimators import CustomProbabilityThresholdClassifie
 
 def test_probability_threshold():
     # loading dataset
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     assert isinstance(data, pd.DataFrame)
 
     # init setup

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -11,7 +11,7 @@ import pycaret.regression
 
 @pytest.fixture(scope="module")
 def boston_dataframe():
-    return pycaret.datasets.get_data("boston")
+    return pycaret.datasets.get_data("boston", save_copy=True)
 
 
 @pytest.mark.parametrize("return_train_score", [True, False])
@@ -196,7 +196,7 @@ class TestRegressionExperimentCustomTags:
         with pytest.raises(Exception):
             # init setup
             _ = pycaret.regression.setup(
-                pycaret.datasets.get_data("boston"),
+                pycaret.datasets.get_data("boston", save_copy=True),
                 target="medv",
                 log_experiment=True,
                 html=False,

--- a/tests/test_regression_engines.py
+++ b/tests/test_regression_engines.py
@@ -9,7 +9,7 @@ import pycaret.regression
 def test_engines_setup_global_args():
     """Tests the setting of engines using global arguments in setup."""
 
-    boston_dataframe = pycaret.datasets.get_data("boston")
+    boston_dataframe = pycaret.datasets.get_data("boston", save_copy=True)
     exp = pycaret.regression.RegressionExperiment()
     # init setup
     exp.setup(
@@ -37,7 +37,7 @@ def test_engines_setup_global_args():
 def test_engines_global_methods():
     """Tests the setting of engines using methods like set_engine (global changes)."""
 
-    boston_dataframe = pycaret.datasets.get_data("boston")
+    boston_dataframe = pycaret.datasets.get_data("boston", save_copy=True)
     exp = pycaret.regression.RegressionExperiment()
 
     # init setup
@@ -67,7 +67,7 @@ def test_engines_global_methods():
 def test_create_model_engines_local_args():
     """Tests the setting of engines for create_model using local args."""
 
-    boston_dataframe = pycaret.datasets.get_data("boston")
+    boston_dataframe = pycaret.datasets.get_data("boston", save_copy=True)
     exp = pycaret.regression.RegressionExperiment()
 
     exp.setup(
@@ -101,7 +101,7 @@ def test_create_model_engines_local_args():
 def test_compare_models_engines_local_args():
     """Tests the setting of engines for compare_models using local args."""
 
-    boston_dataframe = pycaret.datasets.get_data("boston")
+    boston_dataframe = pycaret.datasets.get_data("boston", save_copy=True)
     exp = pycaret.regression.RegressionExperiment()
 
     exp.setup(
@@ -140,7 +140,7 @@ def test_compare_models_engines_local_args():
 
 @pytest.mark.parametrize("algo", ("lr", "lasso", "ridge", "en", "knn", "svm"))
 def test_sklearnex_model(algo: str):
-    boston_dataframe = pycaret.datasets.get_data("boston")
+    boston_dataframe = pycaret.datasets.get_data("boston", save_copy=True)
     exp = pycaret.regression.RegressionExperiment()
 
     exp.setup(

--- a/tests/test_regression_parallel.py
+++ b/tests/test_regression_parallel.py
@@ -6,7 +6,7 @@ def test_regression_parallel():
     from pycaret.parallel import FugueBackend
 
     pr.setup(
-        data=get_data("insurance", verbose=False),
+        data=get_data("insurance", verbose=False, save_copy=True),
         target="charges",
         session_id=0,
         n_jobs=1,

--- a/tests/test_regression_plots.py
+++ b/tests/test_regression_plots.py
@@ -7,7 +7,7 @@ import pycaret.regression
 
 @pytest.mark.plotting
 def test_plot():
-    data = pycaret.datasets.get_data("boston")
+    data = pycaret.datasets.get_data("boston", save_copy=True)
     assert isinstance(data, pd.DataFrame)
 
     pycaret.regression.setup(

--- a/tests/test_regression_tuning.py
+++ b/tests/test_regression_tuning.py
@@ -14,7 +14,7 @@ if sys.platform == "linux":
 @pytest.mark.skip(reason="no way of currently testing this")
 def test_regression_tuning():
     # loading dataset
-    data = pycaret.datasets.get_data("boston")
+    data = pycaret.datasets.get_data("boston", save_copy=True)
     assert isinstance(data, pd.DataFrame)
 
     # init setup

--- a/tests/test_supervised_predict_model.py
+++ b/tests/test_supervised_predict_model.py
@@ -11,7 +11,7 @@ def test_classification_predict_model():
     # It should be revised and this comment should be deleted.
 
     # loading classification dataset
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     assert isinstance(data, pd.DataFrame)
 
     # Check class distribution in the original dataset
@@ -65,7 +65,7 @@ def test_classification_predict_model():
 
 def test_multiclass_predict_model():
     # loading classification dataset
-    data = pycaret.datasets.get_data("iris")
+    data = pycaret.datasets.get_data("iris", save_copy=True)
     assert isinstance(data, pd.DataFrame)
 
     training_data = data.sample(frac=0.90)
@@ -109,7 +109,7 @@ def test_multiclass_predict_model():
 
 def test_regression_predict_model():
     # loading classification dataset
-    data = pycaret.datasets.get_data("boston")
+    data = pycaret.datasets.get_data("boston", save_copy=True)
     assert isinstance(data, pd.DataFrame)
 
     training_data = data.sample(frac=0.90)

--- a/tests/test_time_series_blending.py
+++ b/tests/test_time_series_blending.py
@@ -45,7 +45,7 @@ def test_blend_model_basic(load_setup, load_models, method):
 
 def test_blend_models_tuning():
     """Test the tuning of blended models."""
-    data = get_data("airline", verbose=False)
+    data = get_data("airline", verbose=False, save_copy=True)
     assert isinstance(data, (pd.Series, pd.DataFrame))
 
     exp = TSForecastingExperiment()
@@ -157,7 +157,7 @@ def test_blend_with_larger_predict_fh():
     used in predictions is larger than the one used for training
     Ref: https://github.com/sktime/pycaret/issues/2329
     """
-    data = get_data("airline", verbose=False)
+    data = get_data("airline", verbose=False, save_copy=True)
     assert isinstance(data, (pd.Series, pd.DataFrame))
 
     exp = TSForecastingExperiment()

--- a/tests/test_time_series_indices.py
+++ b/tests/test_time_series_indices.py
@@ -20,7 +20,7 @@ def _get_univar_noexo_data_with_index_index():
     where the index has been set to various types of indices.
     """
     # PeriodIndex
-    data1 = get_data("airline")
+    data1 = get_data("airline", save_copy=True)
 
     # DatetimeIndex
     data2 = data1.copy()
@@ -44,7 +44,7 @@ def _get_univar_noexo_data_with_index_column():
     where the index is specified through a column of different.
     """
     # PeriodIndex column
-    data1 = pd.DataFrame(get_data("airline"))
+    data1 = pd.DataFrame(get_data("airline", save_copy=True))
 
     # DatetimeIndex column
     data2 = data1.copy()

--- a/tests/test_time_series_metrics.py
+++ b/tests/test_time_series_metrics.py
@@ -81,7 +81,7 @@ def test_metrics_with_missing_values_noexo():
     """
 
     # Load data and simulate missing values ----
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     remove_n = int(0.4 * len(data))
     np.random.seed(42)
     na_indices = np.random.choice(data.index, remove_n, replace=False)
@@ -133,7 +133,7 @@ def test_metrics_with_missing_values_exo():
     """
 
     # Load data and simulate missing values ----
-    data = get_data("uschange")
+    data = get_data("uschange", save_copy=True)
     target = "Consumption"
 
     remove_n = int(0.4 * len(data))

--- a/tests/test_time_series_parallel.py
+++ b/tests/test_time_series_parallel.py
@@ -7,7 +7,7 @@ def test_ts_parallel():
     exp = pt.TSForecastingExperiment()
 
     exp.setup(
-        data_func=lambda: get_data("airline", verbose=False),
+        data_func=lambda: get_data("airline", verbose=False, save_copy=True),
         fh=12,
         fold=3,
         fig_kwargs={"renderer": "notebook"},
@@ -34,7 +34,7 @@ def test_ts_parallel():
 
 def test_ts_parallel_singleton():
     pt.setup(
-        data_func=lambda: get_data("airline", verbose=False),
+        data_func=lambda: get_data("airline", verbose=False, save_copy=True),
         fh=12,
         fold=3,
         fig_kwargs={"renderer": "notebook"},

--- a/tests/test_time_series_plots.py
+++ b/tests/test_time_series_plots.py
@@ -363,7 +363,7 @@ def test_plot_final_model_exo():
     """Tests running plot model after running finalize_model when exogenous
     variables are present. Fix for https://github.com/sktime/pycaret/issues/3565
     """
-    data = get_data("uschange")
+    data = get_data("uschange", save_copy=True)
     target = "Consumption"
     FH = 3
     train = data.iloc[: int(len(data) - FH)]

--- a/tests/test_time_series_setup.py
+++ b/tests/test_time_series_setup.py
@@ -188,7 +188,7 @@ def test_sp_to_use_using_index_and_user_def():
     """
 
     exp = TSForecastingExperiment()
-    data = get_data("airline", verbose=False)
+    data = get_data("airline", verbose=False, save_copy=True)
 
     # 1.1 Airline Data with seasonality of 12
     exp.setup(
@@ -226,7 +226,9 @@ def test_sp_to_use_using_index_and_user_def():
     assert exp.primary_sp_to_use == 12
 
     # 1.3 White noise Data with seasonality of 12
-    data = get_data("1", folder="time_series/white_noise", verbose=False)
+    data = get_data(
+        "1", folder="time_series/white_noise", verbose=False, save_copy=True
+    )
     exp.setup(
         data=data,
         sp_detection="index",
@@ -247,7 +249,9 @@ def test_sp_to_use_using_index_and_user_def():
     assert exp.primary_sp_to_use == 1
 
     # 1.4 White noise Data with seasonality of 12 and ignore_seasonality_test = True
-    data = get_data("1", folder="time_series/white_noise", verbose=False)
+    data = get_data(
+        "1", folder="time_series/white_noise", verbose=False, save_copy=True
+    )
     exp.setup(
         data=data,
         sp_detection="index",
@@ -275,7 +279,7 @@ def test_sp_to_use_using_auto_and_user_def():
     """
 
     exp = TSForecastingExperiment()
-    data = get_data("airline", verbose=False)
+    data = get_data("airline", verbose=False, save_copy=True)
 
     # 1.1 Auto Detection of Seasonal Period ----
     exp.setup(
@@ -377,7 +381,7 @@ def test_sp_to_use_using_auto_and_user_def():
 
 def test_sp_to_use_upto_max_sp():
     """Seasonal Period detection upto a max seasonal period provided by user."""
-    data = get_data("airline", verbose=False)
+    data = get_data("airline", verbose=False, save_copy=True)
 
     # 1.0 Max SP not specified ----
     exp = TSForecastingExperiment()
@@ -945,7 +949,7 @@ def test_hyperparameter_splits():
     """Tests the splits to use to determine the hyperparameters"""
 
     # 1.0 Recommended d, white noise, seasonal_period ----
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
 
     FOLD = 1
     FH = 60
@@ -967,7 +971,7 @@ def test_hyperparameter_splits():
     assert exp1.uppercase_d == exp2.uppercase_d
 
     # 2.0 Recommended Seasonal D
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
 
     FOLD = 1
     FH = 36
@@ -1129,7 +1133,7 @@ def test_seasonality_type_auto_with_season_strictly_pos(
     # -------------------------------------------------------------------------#
     # Test 2B: Multiplicative Seasonality (2)
     # -------------------------------------------------------------------------#
-    y = get_data("airline", verbose=False)
+    y = get_data("airline", verbose=False, save_copy=True)
 
     err_msg = "Expected multiplicative seasonality, got additive (2)"
     exp = TSForecastingExperiment()

--- a/tests/test_tune_model.py
+++ b/tests/test_tune_model.py
@@ -8,7 +8,7 @@ from pycaret.regression import RegressionExperiment
 @pytest.mark.parametrize("usecase", ("classification", "regression"))
 def test_tunable_voting_estimator(usecase):
     # load dataset
-    diabetes = get_data("diabetes")
+    diabetes = get_data("diabetes", save_copy=True)
 
     # init setup
     if usecase == "classification":
@@ -39,7 +39,7 @@ def test_tunable_voting_estimator(usecase):
 @pytest.mark.parametrize("usecase", ("classification", "regression"))
 def test_tunable_mlp(usecase):
     # load dataset
-    diabetes = get_data("diabetes")
+    diabetes = get_data("diabetes", save_copy=True)
 
     # init setup
     if usecase == "classification":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,7 @@ def test_utils():
     assert isinstance(version, str)
 
     # preparation(classification)
-    data = pycaret.datasets.get_data("juice")
+    data = pycaret.datasets.get_data("juice", save_copy=True)
     train, test = sklearn.model_selection.train_test_split(
         data, train_size=0.8, random_state=1
     )
@@ -79,7 +79,7 @@ def test_utils():
     assert mcc <= 1
 
     # preparation(regression)
-    data = pycaret.datasets.get_data("boston")
+    data = pycaret.datasets.get_data("boston", save_copy=True)
     train, test = sklearn.model_selection.train_test_split(
         data, train_size=0.8, random_state=1
     )
@@ -135,7 +135,7 @@ def test_utils():
     npt.assert_almost_equal(mape, 0.045, decimal=2)
 
     # preparation (timeseries)
-    data = pycaret.datasets.get_data("airline", verbose=False)
+    data = pycaret.datasets.get_data("airline", verbose=False, save_copy=True)
     train, test = sklearn.model_selection.train_test_split(
         data, train_size=0.8, random_state=1, shuffle=False
     )

--- a/tests/test_utils_datetime.py
+++ b/tests/test_utils_datetime.py
@@ -14,7 +14,7 @@ def test_coerce_period_to_datetime_index():
     """Tests coercion of PeriodIndex to DatetimeIndex"""
 
     # TODO: Get both Series and DataFrame with Period Index later
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     orig_freq = data.index.freq
 
     # Basic coercion ----
@@ -42,7 +42,7 @@ def test_coerce_period_to_datetime_index():
     assert isinstance(data_np_new, np.ndarray)
 
     # No Coercion (Pandas Int Index)
-    data = get_data("uschange")
+    data = get_data("uschange", save_copy=True)
     original_index_type = type(data.index)
     new_data = coerce_period_to_datetime_index(data=data)
     assert isinstance(new_data.index, original_index_type)
@@ -65,7 +65,7 @@ def test_coerce_datetime_to_period_index():
     represent Month.
     """
     # TODO: Get both Series and DataFrame with Period Index later
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     data.index = data.index.to_timestamp()
 
     # Basic coercion ----
@@ -90,7 +90,7 @@ def test_coerce_datetime_to_period_index():
     assert isinstance(data_np_new, np.ndarray)
 
     # No Coercion (Pandas Int Index)
-    data = get_data("uschange")
+    data = get_data("uschange", save_copy=True)
     original_index_type = type(data.index)
     new_data = coerce_datetime_to_period_index(data=data)
     assert isinstance(new_data.index, original_index_type)

--- a/tests/time_series_test_utils.py
+++ b/tests/time_series_test_utils.py
@@ -66,7 +66,7 @@ _SCALE_METHODS = ["zscore", "minmax", "maxabs", "robust"]
 
 def _get_all_plots():
     exp = TSForecastingExperiment()
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     exp.setup(data=data)
     all_plots = list(exp._available_plots.keys())
     all_plots = [None] + all_plots
@@ -75,7 +75,7 @@ def _get_all_plots():
 
 def _get_all_plots_data():
     exp = TSForecastingExperiment()
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     exp.setup(data=data)
     all_plots = exp._available_plots_data_keys
     all_plots = [None] + all_plots
@@ -84,7 +84,7 @@ def _get_all_plots_data():
 
 def _get_all_plots_estimator():
     exp = TSForecastingExperiment()
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     exp.setup(data=data)
     all_plots = exp._available_plots_estimator_keys
     all_plots = [None] + all_plots
@@ -110,7 +110,7 @@ def _return_all_plots_estimator_ts_results():
 
 def _get_all_metrics():
     exp = TSForecastingExperiment()
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     exp.setup(data=data)
     all_metrics = exp.get_metrics()["Name"].to_list()
     return all_metrics
@@ -144,7 +144,7 @@ def _check_windows():
 
 def _return_model_names():
     """Return all model names."""
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     exp = TSForecastingExperiment()
     exp.setup(data=data, session_id=42)
     model_containers = get_all_model_containers(exp)
@@ -286,8 +286,8 @@ def _return_setup_args_raises():
 def _return_data_with_without_period_index():
     """Returns one dataset with period index and one with int index"""
     datasets = [
-        get_data("airline"),
-        get_data("10", folder="time_series/white_noise"),
+        get_data("airline", save_copy=True),
+        get_data("10", folder="time_series/white_noise", save_copy=True),
     ]
     return datasets
 
@@ -323,7 +323,7 @@ def assert_frame_not_equal(*args, **kwargs):
 
 def _return_data_big_small():
     """Returns one dataset with 144 data points and one with < 12 data points"""
-    data = get_data("airline")
+    data = get_data("airline", save_copy=True)
     data = data - 400
     data_small = data[:11]  # 11 data points
     datasets = [data, data_small]


### PR DESCRIPTION
## About
This patch includes just a minor adjustment to how datasets are loaded. It shouldn't do any harm, but on the other hand might not improve much.

## What's inside

### In tests, use `pycaret.datasets.get_data` with `save_copy=True`

This will save a local copy of a data asset file after eventually loading it via HTTP. On subsequent requests, the local file will be used automatically?, so that might save a few cycles.
