### PR TITLE
[ENH] Prefer loading datasets via sktime instead of HTTP

### DIFF
--- a/pycaret/datasets.py
+++ b/pycaret/datasets.py
@@ -113,8 +113,6 @@ def get_data(
     # If that does not exist then read sktime datasets
     if os.path.isfile(filename):
         data = pd.read_csv(filename)
-    elif requests.get(complete_address).status_code == 200:
-        data = pd.read_csv(complete_address)
     elif dataset in sktime_datasets:
         from sktime.datasets import load_airline, load_lynx, load_uschange
 
@@ -128,6 +126,8 @@ def get_data(
             y = data[0]
             X = data[1]
             data = pd.concat([y, X], axis=1)
+    elif requests.head(complete_address).status_code == 200:
+        data = pd.read_csv(complete_address)
     else:
         raise ValueError("Data could not be read. Please check your inputs...")
 


### PR DESCRIPTION
## About
This patch includes just a minor adjustment to how datasets are loaded. It shouldn't do any harm, but on the other hand might not improve much.

## What's inside

### Prefer loading datasets via sktime instead of HTTP

After trying via sktime, then falling back to HTTP requests to https://github.com/pycaret/datasets, the code is now emitting HEAD requests instead of GET for probing about file existence, which might reduce a bit of overhead.