### PR TITLE
[MNT] Remove dependency to `trio`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,6 @@ dependencies = [
   "psutil>=5.9.0",
   "cloudpickle",
   "xxhash",
-  "trio>=0.22.0,<0.25.0; python_version<'3.13'",
-  "trio>=0.27.0; python_version>='3.13'",
   "setuptools; python_version>='3.12'",
   "packaging>=21.0",
   # Plotting


### PR DESCRIPTION
I wasn't able to find any references to the [trio](https://pypi.org/project/trio/) package. Did I miss them?